### PR TITLE
PETPVC fixes

### DIFF
--- a/petprep/interfaces/pvc.py
+++ b/petprep/interfaces/pvc.py
@@ -15,6 +15,78 @@ import os
 
 from nipype.interfaces.freesurfer.base import FSCommand, FSTraitedSpec
 
+class ClipValuesInputSpec(BaseInterfaceInputSpec):
+    in_file = File(exists=True, mandatory=True, desc="Input image file")
+    out_file = File("handled_volume.nii.gz", usedefault=True, desc="Output handled image file")
+
+class ClipValuesOutputSpec(TraitedSpec):
+    out_file = File(exists=True, desc="Output handled image file")
+
+class ClipValues(BaseInterface):
+    input_spec = ClipValuesInputSpec
+    output_spec = ClipValuesOutputSpec
+
+    def _run_interface(self, runtime):
+        in_img = nb.load(self.inputs.in_file)
+        in_data = in_img.get_fdata()
+
+        # Handle negative values, infinities, and NaNs
+        clipped_data = np.clip(in_data, 0, None)
+        clipped_data = clipped_data.astype(np.float32)
+
+        new_img = nb.Nifti1Image(clipped_data, affine=in_img.affine, header=in_img.header)
+        nb.save(new_img, os.path.abspath(self.inputs.out_file))
+
+        return runtime
+
+    def _list_outputs(self):
+        return {"out_file": os.path.abspath(self.inputs.out_file)}
+
+class DiscardOutliersInputSpec(BaseInterfaceInputSpec):
+    in_file = File(exists=True, mandatory=True, desc="Input image file")
+    out_file = File("discarded_outliers.nii.gz", usedefault=True, desc="Output image file with outliers discarded")
+    threshold = traits.Float(3.0, usedefault=True, desc="Threshold for outlier detection (in terms of MAD)")
+
+class DiscardOutliersOutputSpec(TraitedSpec):
+    out_file = File(exists=True, desc="Output image file with outliers discarded")
+    
+class DiscardOutliers(BaseInterface):
+    input_spec = DiscardOutliersInputSpec
+    output_spec = DiscardOutliersOutputSpec
+
+    def _run_interface(self, runtime):
+        in_img = nb.load(self.inputs.in_file)
+        in_data = in_img.get_fdata()
+        
+        # Find inf values and NaNs
+        inf_mask = np.isinf(in_data)
+        nan_mask = np.isnan(in_data)
+
+        # Combine masks
+        outlier_mask = inf_mask #| nan_mask
+        
+        # Set outliers to zero
+        in_data[outlier_mask] = np.nan
+        in_data_flat = in_data.flatten()
+        
+        # Calculate the median and MAD
+        median = np.nanmedian(in_data_flat[in_data_flat!=0])
+        mad = np.nanmedian(np.abs(in_data_flat - median))
+        
+        # Identify outliers based on the threshold
+        threshold = self.inputs.threshold * mad
+        outlier_mask = np.abs(in_data - median) > threshold
+        
+        # Set outliers as NaN
+        in_data[outlier_mask] = np.nan
+
+        new_img = nb.Nifti1Image(in_data, affine=in_img.affine, header=in_img.header)
+        nb.save(new_img, os.path.abspath(self.inputs.out_file))
+
+        return runtime
+
+    def _list_outputs(self):
+        return {"out_file": os.path.abspath(self.inputs.out_file)}
 
 class Binarise4DSegmentationInputSpec(BaseInterfaceInputSpec):
     dseg_file = File(exists=True, mandatory=True, desc="Input segmentation file (_dseg.nii.gz)")

--- a/petprep/workflows/pet/pvc.py
+++ b/petprep/workflows/pet/pvc.py
@@ -88,6 +88,12 @@ def init_pet_pvc_wf(
             iterfield=['in_file'],
             name=f'{tool_lower}_{method_key.lower()}_pvc_node',
         )
+        
+        discard_outliers = pe.MapNode(
+            DiscardOutliers(),
+            iterfield=['in_file'],
+            name='discard_outliers'
+        )
 
         workflow.connect([
             (inputnode, split_frames, [('pet_file', 'in_file')]),

--- a/petprep/workflows/pet/pvc.py
+++ b/petprep/workflows/pet/pvc.py
@@ -9,7 +9,9 @@ from nipype.interfaces.fsl import Split, Merge
 import nibabel as nb
 from nipype.interfaces.freesurfer import ApplyVolTransform, Tkregister2, MRICoreg
 
-from petprep.interfaces.pvc import CSVtoNifti, StackTissueProbabilityMaps, Binarise4DSegmentation, GTMPVC, GTMStatsTo4DNifti
+from petprep.interfaces.pvc import (CSVtoNifti, StackTissueProbabilityMaps, 
+                                    Binarise4DSegmentation, GTMPVC, GTMStatsTo4DNifti,
+                                    ClipValues, DiscardOutliers)
 
 
 def load_pvc_config(config_path: Path) -> dict:
@@ -99,44 +101,41 @@ def init_pet_pvc_wf(
             (inputnode, split_frames, [('pet_file', 'in_file')]),
             (split_frames, resample_pet_to_anat, [('out_files', 'source_file')]),
             (inputnode, resample_pet_to_anat, [('segmentation', 'target_file')]),
-            (resample_pet_to_anat, pvc_node, [('transformed_file', 'in_file')]),
+            (resample_pet_to_anat, clip_values, [('transformed_file', 'in_file')]),
+            (clip_values, pvc_node, [('out_file', 'in_file')]),
         ])
-
-        if method_key == 'MG':
-            stack_node = pe.Node(StackTissueProbabilityMaps(), name='stack_probmaps')
-            workflow.connect([
-                (inputnode, stack_node, [('t1w_tpms', 't1w_tpms')]),
-                (stack_node, pvc_node, [('out_file', 'mask_file')]),
-                (pvc_node, merge_frames, [('out_file', 'in_files')]),
-            ])
-
-        else:
+        
+            
+        if method_key == 'GTM':
             binarise_segmentation = pe.Node(Binarise4DSegmentation(), name='binarise_segmentation')
             workflow.connect([
                 (inputnode, binarise_segmentation, [('segmentation', 'dseg_file')]),
                 (binarise_segmentation, pvc_node, [('out_file', 'mask_file')]),
             ])
 
-            if method_key == 'GTM':
-                pvc_node.inputs.out_file = 'gtm_output.csv'
+            pvc_node.inputs.out_file = 'gtm_output.csv'
 
-                csv_to_nifti_node = pe.MapNode(
-                    CSVtoNifti(),
-                    iterfield=['csv_file'],
-                    name='csv_to_nifti_node'
-                )
+            csv_to_nifti_node = pe.MapNode(
+                CSVtoNifti(),
+                iterfield=['csv_file'],
+                name='csv_to_nifti_node'
+            )
 
-                workflow.connect([
-                    (pvc_node, csv_to_nifti_node, [('out_file', 'csv_file')]),
-                    (binarise_segmentation, csv_to_nifti_node, [('label_list', 'label_list')]),
-                    (inputnode, csv_to_nifti_node, [('segmentation', 'reference_nifti')]),
-                    (csv_to_nifti_node, merge_frames, [('out_file', 'in_files')]),
-                ])
+            workflow.connect([
+                (pvc_node, csv_to_nifti_node, [('out_file', 'csv_file')]),
+                (binarise_segmentation, csv_to_nifti_node, [('label_list', 'label_list')]),
+                (inputnode, csv_to_nifti_node, [('segmentation', 'reference_nifti')]),
+                (csv_to_nifti_node, merge_frames, [('out_file', 'in_files')]),
+            ])
 
-            else:
-                workflow.connect([
-                    (pvc_node, merge_frames, [('out_file', 'in_files')]),
-                ])
+        else:
+            stack_node = pe.Node(StackTissueProbabilityMaps(), name='stack_probmaps')
+            workflow.connect([
+                (inputnode, stack_node, [('t1w_tpms', 't1w_tpms')]),
+                (stack_node, pvc_node, [('out_file', 'mask_file')]),
+                (pvc_node, discard_outliers, [('out_file', 'in_file')]),
+                (discard_outliers, merge_frames, [('out_file', 'in_files')]),
+            ])
 
         workflow.connect([
             (merge_frames, resample_pet_to_petref, [('merged_file', 'source_file')]),

--- a/petprep/workflows/pet/pvc.py
+++ b/petprep/workflows/pet/pvc.py
@@ -76,7 +76,13 @@ def init_pet_pvc_wf(
             iterfield=['source_file'],
             name='resample_pet_to_anat'
         )
-
+        
+        clip_values = pe.MapNode(
+            ClipValues(),
+            iterfield=['in_file'],
+            name='clip_values'
+        )
+        
         pvc_node = pe.MapNode(
             PETPVC(pvc=method_config.pop('pvc'), **method_config),
             iterfield=['in_file'],


### PR DESCRIPTION
Workflow for PETPVC was enhanced with the following features:

1. Clipping function to set negative values caused by filtered backpropagation to 0
2. Discard outliers by converting extreme values beyond 3 median absolute deviations to NaNs
3. Add extra volume that represents background voxels when stacking tissue probability masks (see https://github.com/UCL/PETPVC/issues/106)
4. Reorganised workflow to only binarise segmentation when GTM method is used