### PR TITLE
ENH: add ref_mask arguments to parser

### DIFF
--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -554,6 +554,13 @@ https://petprep.readthedocs.io/en/%s/spaces.html"""
         help='Segmentation method to use.',
     )
 
+    g_refmask = parser.add_argument_group('Options for reference mask generation')
+    g_refmask.add_argument(
+        '--ref-mask-name',
+        choices=['cerebellum'],
+        help='Predefined reference regions',
+    )
+
     g_pvc = parser.add_argument_group('Options for partial volume correction')
     parser.add_argument('--pvc-tool', choices=['petpvc', 'petsurfer'], help='Tool to use for partial volume correction')
     g_pvc.add_argument('--pvc-method', action='store', help='PVC method identifier')


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

<!--
Please describe here the main features / changes proposed for review and integration in PETPrep
If this PR addresses some existing problem, please use GitHub's citing tools
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *PETPrep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->
This PR adds the argument group for the new refmask workflow. 


## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->
This PR only adds the parser to provide a pre-defined refregion. We start with the cerebellum. More regions and functions to be added later on.


<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/nipreps/petprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (Apache License 2.0) as the rest of PETPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/nipreps/petprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
