### PR TITLE
chore: Disable calver for now, use guess-next-dev (default)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,8 @@ exclude = [
 
 [tool.hatch.version]
 source = "vcs"
-raw-options = { version_scheme = "nipreps-calver" }
+## Uncomment to enable calver
+# raw-options = { version_scheme = "nipreps-calver" }
 
 [tool.hatch.build.hooks.vcs]
 version-file = "petprep/_version.py"


### PR DESCRIPTION
Since we're targeting a 0.0.1 release, it doesn't make sense to have 25.0.0 dev versions for now.