### PR TITLE
Check to see if docker cache stays intact when run directly in workflows.

### DIFF
--- a/.github/workflows/docker_local_cache.yml
+++ b/.github/workflows/docker_local_cache.yml
@@ -1,0 +1,48 @@
+name: Docker build (cache w/ docker)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "master", "main", "maint/*", "gha-docker-build" ]
+    tags: "*"
+  pull_request:
+    branches: [ "master", "main", "maint/*" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  FORCE_COLOR: true
+
+jobs:
+  build-container:
+    runs-on: local
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 200
+          fetch-tags: true
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+
+      - name: Extract Docker metadata
+        id: meta
+        run: |
+          # Simple tag generation
+          TAGS="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main"
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "labels=" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image
+        run: |
+          docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main .


### PR DESCRIPTION
…f docker build.

<!--
Text in these brackets are comments, and won't be visible when you submit your pull request.
If this is your first contribution, please take the time to read these, in particular the comment
beginning "Welcome, new contributors!".
-->

## Changes proposed in this pull request

Only a test, don't merge this. Just trying to make the actions not clean up so well after themselves and speed up the build process. The hope is that by running these docker build commands directly we can save on downloading Freesurfer.

## Documentation that should be reviewed
<!--
Please summarize here the main changes to the documentation that the reviewers should be aware of.
-->



<!--
Welcome, new contributors!

We ask you to read through the Contributing Guide:
https://github.com/nipreps/petprep/blob/master/CONTRIBUTING.md

These are guidelines intended to make communication easier by describing a consistent process, but
don't worry if you don't get it everything exactly "right" on the first try.

To boil it down, here are some highlights:

1) Consider starting a conversation in the issues list before submitting a pull request. The discussion might save you a
   lot of time coding.
2) Please use descriptive prefixes in your pull request title, such as "ENH:" for an enhancement or "FIX:" for a bug fix.
   (See the Contributing guide for the full set.) And consider adding a "WIP" tag for works-in-progress.
3) Any code you submit will be licensed under the same terms (Apache License 2.0) as the rest of PETPrep.
4) We invite every contributor to add themselves to the `.zenodo.json` file
   (https://github.com/nipreps/petprep/blob/master/.zenodo.json), which will result in your being listed as an author
   at the next release. Please add yourself as the next-to-last entry, just above Russ.

A pull request is a conversation. We may ask you to make some changes before accepting your PR,
and likewise, you should feel free to ask us any questions you have.

-->
