### PR TITLE
DOC: Fix the path to the `sample_report` folder in the output doc

### DIFF
--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -84,7 +84,7 @@ Visual Reports
 --------------
 *PETPrep* outputs summary reports, written to ``<output dir>/petprep/sub-<subject_label>.html``.
 These reports provide a quick way to make visual inspection of the results easy.
-`View a sample report. <_static/SampleReport/sample_report.html>`_
+`View a sample report. <_static/sample_report/sample_report.html>`_
 
 Derivatives of *PETPrep* (preprocessed data)
 ---------------------------------------------


### PR DESCRIPTION
## Changes proposed in this pull request

Fix the path to the `sample_report` folder in the output doc: it was renamed it in commit 4bdc61f to stick to the lowercase, underscore convention.

## Documentation that should be reviewed

Check website when it gets build and deployed.
