### PR TITLE
ENH: add suffix pet to refmask report datasink

### DIFF
--- a/petprep/workflows/pet/outputs.py
+++ b/petprep/workflows/pet/outputs.py
@@ -997,6 +997,7 @@ def init_refmask_report_wf(
             ref=ref_name,
             datatype='figures',
             allowed_entities=('ref',),
+            suffix='pet',
         ),
         name='ds_report_refmask',
         run_without_submitting=True,

--- a/petprep/workflows/pet/tests/test_fit.py
+++ b/petprep/workflows/pet/tests/test_fit.py
@@ -343,6 +343,7 @@ def test_init_refmask_report_wf(tmp_path: Path):
     ds = wf.get_node('ds_report_refmask')
     assert ds.inputs.desc == 'refmask'
     assert ds.inputs.ref == 'test'
+    assert ds.inputs.suffix == 'pet'
 
 
 def test_reports_spec_contains_refmask():


### PR DESCRIPTION
This PR targets issue #86, ensuring that reference-mask reports carry a PET-specific suffix by adding suffix='pet' to the report data sink definition, overriding any inherited suffix from the validated source file

Second, it also updates the refmask report workflow test to assert the presence of the PET suffix in the output node configuration.