### PR TITLE
DOC: Make the copyright start year match the initial commit year

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,7 +87,7 @@ master_doc = 'index'
 # General information about the project.
 project = 'petprep'
 author = 'The PETPrep developers'
-copyright = f'2016-, {author}'
+copyright = f'2023-, {author}'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
## Changes proposed in this pull request

Make the copyright start year match the initial commit year. 2016 was a leftover from fMRIPrep.

## Documentation that should be reviewed

N/A