### PR TITLE
ENH: Refactor PET workflow segmentation process

### DIFF
--- a/petprep/workflows/base.py
+++ b/petprep/workflows/base.py
@@ -524,9 +524,6 @@ It is released under the [CC0]\
                 ]),
             ])  # fmt:skip
 
-    if config.workflow.anat_only:
-        return clean_datasinks(workflow)
-
     segmentation_wf = init_segmentation_wf(
         seg=config.workflow.seg,
         name=f'pet_{config.workflow.seg}_seg_wf',
@@ -544,6 +541,9 @@ It is released under the [CC0]\
             ),
         ]
     )
+
+    if config.workflow.anat_only:
+        return clean_datasinks(workflow)
 
     # Append the PET section to the existing anatomical excerpt
     # That way we do not need to filter down the number of PET datasets

--- a/petprep/workflows/pet/base.py
+++ b/petprep/workflows/pet/base.py
@@ -115,6 +115,10 @@ def init_pet_wf(
         Registration spheres from fsnative to fsLR space, collated left, then right
     anat_ribbon
         Binary cortical ribbon mask in T1w space
+    segmentation
+        Segmentation file in T1w space
+    dseg_tsv
+        TSV with segmentation statistics
     anat2std_xfm
         Transform from anatomical space to standard space
     std_t1w
@@ -206,6 +210,8 @@ configured with cubic B-spline interpolation.
                 'midthickness_fsLR',
                 'cortex_mask',
                 'anat_ribbon',
+                'segmentation',
+                'dseg_tsv',
                 # Volumetric templates
                 'anat2std_xfm',
                 'std_t1w',
@@ -242,6 +248,8 @@ configured with cubic B-spline interpolation.
             ('subjects_dir', 'inputnode.subjects_dir'),
             ('subject_id', 'inputnode.subject_id'),
             ('fsnative2t1w_xfm', 'inputnode.fsnative2t1w_xfm'),
+            ('segmentation', 'inputnode.segmentation'),
+            ('dseg_tsv', 'inputnode.dseg_tsv'),
         ]),
     ])  # fmt:skip
 

--- a/petprep/workflows/pet/base.py
+++ b/petprep/workflows/pet/base.py
@@ -399,9 +399,7 @@ configured with cubic B-spline interpolation.
                 ('t1w_tpms', 'inputnode.t1w_tpms'),
                 ('subjects_dir', 'inputnode.subjects_dir'),
                 ('subject_id', 'inputnode.subject_id'),
-            ]),
-            (pet_fit_wf, pet_pvc_wf, [
-                ('outputnode.segmentation', 'inputnode.segmentation'),
+                ('segmentation', 'inputnode.segmentation'),
             ]),
             (petref_t1w, pet_pvc_wf, [('output_image', 'inputnode.petref')]),
             (pet_pvc_wf, psf_meta, [
@@ -719,9 +717,9 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
 
     workflow.connect([
         (pet_t1w_src, pet_tacs_wf, [(pet_t1w_field, 'inputnode.pet_anat')]),
-        (pet_fit_wf, pet_tacs_wf, [
-            ('outputnode.segmentation', 'inputnode.segmentation'),
-            ('outputnode.dseg_tsv', 'inputnode.dseg_tsv'),
+        (inputnode, pet_tacs_wf, [
+            ('segmentation', 'inputnode.segmentation'),
+            ('dseg_tsv', 'inputnode.dseg_tsv'),
         ]),
         (pet_tacs_wf, ds_pet_tacs, [('outputnode.timeseries', 'in_file')]),
     ])  # fmt:skip

--- a/petprep/workflows/pet/fit.py
+++ b/petprep/workflows/pet/fit.py
@@ -119,10 +119,6 @@ def init_pet_fit_wf(
     petref2anat_xfm
         Affine transform mapping from PET reference space to the anatomical
         space.
-    segmentation
-        Segmentation file in T1w space
-    dseg_tsv
-        TSV with segmentation statistics
 
     See Also
     --------
@@ -191,8 +187,6 @@ def init_pet_fit_wf(
                 'pet_mask',
                 'motion_xfm',
                 'petref2anat_xfm',
-                'segmentation',
-                'dseg_tsv',
                 'refmask',
             ],
         ),
@@ -201,11 +195,6 @@ def init_pet_fit_wf(
 
     # If all derivatives exist, inputnode could go unconnected, so add explicitly
     workflow.add_nodes([inputnode])
-    workflow.connect(
-        [
-            (inputnode, outputnode, [('segmentation', 'segmentation'), ('dseg_tsv', 'dseg_tsv')]),
-        ]
-    )
 
     petref_buffer = pe.Node(
         niu.IdentityInterface(fields=['petref', 'pet_file']),

--- a/petprep/workflows/pet/fit.py
+++ b/petprep/workflows/pet/fit.py
@@ -555,7 +555,7 @@ def init_pet_fit_wf(
             ]
         )
     else:
-        config.loggers.workflow.info('PET Stage 5: Reference mask generation skipped')
+        config.loggers.workflow.info('PET Stage 4: Reference mask generation skipped')
 
     return workflow
 

--- a/petprep/workflows/pet/tests/test_base.py
+++ b/petprep/workflows/pet/tests/test_base.py
@@ -205,8 +205,8 @@ def test_pvc_receives_segmentation(bids_root: Path):
 
         wf = init_pet_wf(pet_series=pet_series, precomputed={})
 
-    edge = wf._graph.get_edge_data(wf.get_node('pet_fit_wf'), wf.get_node('pet_pvc_wf'))
-    assert ('outputnode.segmentation', 'inputnode.segmentation') in edge['connect']
+    edge = wf._graph.get_edge_data(wf.get_node('inputnode'), wf.get_node('pet_pvc_wf'))
+    assert ('segmentation', 'inputnode.segmentation') in edge['connect']
 
 
 def test_pet_tacs_wf_connections(bids_root: Path):
@@ -226,9 +226,9 @@ def test_pet_tacs_wf_connections(bids_root: Path):
     edge_anat = wf._graph.get_edge_data(wf.get_node('pet_anat_wf'), wf.get_node('pet_tacs_wf'))
     assert ('outputnode.pet_file', 'inputnode.pet_anat') in edge_anat['connect']
 
-    edge_fit = wf._graph.get_edge_data(wf.get_node('pet_fit_wf'), wf.get_node('pet_tacs_wf'))
-    assert ('outputnode.segmentation', 'inputnode.segmentation') in edge_fit['connect']
-    assert ('outputnode.dseg_tsv', 'inputnode.dseg_tsv') in edge_fit['connect']
+    edge_input = wf._graph.get_edge_data(wf.get_node('inputnode'), wf.get_node('pet_tacs_wf'))
+    assert ('segmentation', 'inputnode.segmentation') in edge_input['connect']
+    assert ('dseg_tsv', 'inputnode.dseg_tsv') in edge_input['connect']
 
     edge_ds = wf._graph.get_edge_data(wf.get_node('pet_tacs_wf'), wf.get_node('ds_pet_tacs'))
     assert ('outputnode.timeseries', 'in_file') in edge_ds['connect']

--- a/petprep/workflows/tests/test_base.py
+++ b/petprep/workflows/tests/test_base.py
@@ -102,9 +102,7 @@ def multisession_bids_root(tmp_path_factory):
     bids_dir = base / 'bids'
     bids_dir.mkdir(parents=True, exist_ok=True)
     img = nb.Nifti1Image(np.zeros((10, 10, 10, 10)), np.eye(4))
-    (bids_dir / 'dataset_description.json').write_text(
-        '{"Name": "Test", "BIDSVersion": "1.8.0"}'
-    )
+    (bids_dir / 'dataset_description.json').write_text('{"Name": "Test", "BIDSVersion": "1.8.0"}')
     for ses in ['01', '02']:
         anat_dir = bids_dir / 'sub-01' / f'ses-{ses}' / 'anat'
         pet_dir = bids_dir / 'sub-01' / f'ses-{ses}' / 'pet'

--- a/petprep/workflows/tests/test_base.py
+++ b/petprep/workflows/tests/test_base.py
@@ -4,8 +4,6 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
-from pathlib import Path
-
 import nibabel as nb
 import numpy as np
 import pytest

--- a/petprep/workflows/tests/test_base.py
+++ b/petprep/workflows/tests/test_base.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
+from pathlib import Path
+
 import nibabel as nb
 import numpy as np
 import pytest
@@ -13,7 +15,7 @@ from niworkflows.utils.bids import collect_data as original_collect_data
 from niworkflows.utils.testing import generate_bids_skeleton
 
 from ... import config
-from ..base import init_petprep_wf
+from ..base import init_petprep_wf, init_single_subject_wf
 from ..tests import mock_config
 
 BASE_LAYOUT = {
@@ -94,6 +96,55 @@ def bids_root(tmp_path_factory):
         events_path.write_text('onset\tduration\ttrial_type\n')
 
     return bids_dir
+
+
+@pytest.fixture(scope='module')
+def multisession_bids_root(tmp_path_factory):
+    base = tmp_path_factory.mktemp('multisession')
+    bids_dir = base / 'bids'
+    bids_dir.mkdir(parents=True, exist_ok=True)
+    img = nb.Nifti1Image(np.zeros((10, 10, 10, 10)), np.eye(4))
+    (bids_dir / 'dataset_description.json').write_text(
+        '{"Name": "Test", "BIDSVersion": "1.8.0"}'
+    )
+    for ses in ['01', '02']:
+        anat_dir = bids_dir / 'sub-01' / f'ses-{ses}' / 'anat'
+        pet_dir = bids_dir / 'sub-01' / f'ses-{ses}' / 'pet'
+        anat_dir.mkdir(parents=True, exist_ok=True)
+        pet_dir.mkdir(parents=True, exist_ok=True)
+        img.to_filename(anat_dir / f'sub-01_ses-{ses}_T1w.nii.gz')
+        pet_path = pet_dir / f'sub-01_ses-{ses}_task-rest_run-1_pet.nii.gz'
+        img.to_filename(pet_path)
+        (pet_path.with_suffix('').with_suffix('.json')).write_text(
+            '{"FrameTimesStart": [0], "FrameDuration": [1]}'
+        )
+    return bids_dir
+
+
+def test_segmentation_shared_across_runs(multisession_bids_root):
+    with mock_config(bids_dir=multisession_bids_root):
+        wf = init_single_subject_wf('01')
+    flatgraph = wf._create_flat_graph()
+    generate_expanded_graph(flatgraph)
+
+    seg_wf_name = f'pet_{config.workflow.seg}_seg_wf'
+    seg_nodes = [n for n in wf.list_node_names() if n.startswith(seg_wf_name)]
+    assert seg_nodes
+
+    pet_wf_names = [
+        n
+        for n in {name.split('.')[0] for name in wf.list_node_names() if name.startswith('pet_')}
+        if n != seg_wf_name
+    ]
+    assert len(pet_wf_names) == 2
+
+    seg_node = wf.get_node(seg_wf_name)
+    for name in pet_wf_names:
+        pet_node = wf.get_node(name)
+        edge = wf._graph.get_edge_data(seg_node, pet_node)
+        assert ('outputnode.segmentation', 'inputnode.segmentation') in edge['connect']
+        assert ('outputnode.dseg_tsv', 'inputnode.dseg_tsv') in edge['connect']
+        assert all('_seg_wf' not in n for n in pet_node.list_node_names())
 
 
 def _make_params(


### PR DESCRIPTION
This PR addresses issue #95 by moving the segmentation part to the subject level instead of the session level. Specifically, this PR

1. Streamlined the PET fit workflow to accept precomputed segmentation data, removing the per-run segmentation stage and using a shared segmentation file for reference mask generation

2. Added a subject-level segmentation step that runs once, then distributes its segmentation and statistics outputs to every PET run

3. Updated the PET workflow to consume and pass along the shared segmentation outputs, ensuring downstream components receive the same data across sessions

4. Introduced a regression test that constructs a multi-session dataset and confirms segmentation executes only once and its outputs are shared across runs