### PR TITLE
WIP: Rename timeseries.tsv to tacs.tsv

### DIFF
--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -309,7 +309,7 @@ from an anatomical segmentation. The resulting table has ``FrameTimesStart`` and
 
   sub-<subject_label>/
     pet/
-      sub-<subject_label>_[specifiers]_seg-<seg>_desc-preproc_timeseries.tsv
+      sub-<subject_label>_[specifiers]_seg-<seg>_desc-preproc_tacs.tsv
 
 The ``desc-preproc`` entity indicates that the curves were derived from the
 preprocessed PET series.
@@ -323,7 +323,7 @@ table containing the mean uptake within that region::
 
   sub-<subject_label>/
     pet/
-      sub-<subject_label>_[specifiers]_seg-<seg>_ref-<ref>_desc-preproc_timeseries.tsv
+      sub-<subject_label>_[specifiers]_seg-<seg>_ref-<ref>_desc-preproc_tacs.tsv
 
 The ``ref`` entity captures the reference region identifier provided via the
 :ref:`CLI options <cli_refmask>` ``--ref-mask-name`` and ``--ref-mask-index``.

--- a/petprep/interfaces/tacs.py
+++ b/petprep/interfaces/tacs.py
@@ -80,7 +80,7 @@ class ExtractTACs(SimpleInterface):
 
         out_file = fname_presuffix(
             self.inputs.in_file,
-            suffix='_timeseries.tsv',
+            suffix='_tacs.tsv',
             newpath=runtime.cwd,
             use_ext=False,
         )
@@ -138,7 +138,7 @@ class ExtractRefTAC(SimpleInterface):
 
         out_file = fname_presuffix(
             self.inputs.in_file,
-            suffix='_timeseries.tsv',
+            suffix='_tacs.tsv',
             newpath=runtime.cwd,
             use_ext=False,
         )

--- a/petprep/interfaces/tests/test_tacs.py
+++ b/petprep/interfaces/tests/test_tacs.py
@@ -164,7 +164,7 @@ def test_tacs_workflow(tmp_path):
         inputs = pickle.load(f)
 
     assert inputs['in_file'] == str(resampled_pet)
-    assert Path(tmp_path / 'pet_tacs_wf' / 'tac' / 'pet_resampled_timeseries.tsv').exists()
+    assert Path(tmp_path / 'pet_tacs_wf' / 'tac' / 'pet_resampled_tacs.tsv').exists()
 
 
 def test_ExtractRefTAC(tmp_path):

--- a/petprep/utils/bids.py
+++ b/petprep/utils/bids.py
@@ -103,6 +103,7 @@ def write_bidsignore(deriv_dir):
         '*_pet.pet.gii',
         '*_mixing.tsv',
         '*_timeseries.tsv',
+        '*_tacs.tsv',
     )
     ignore_file = Path(deriv_dir) / '.bidsignore'
 

--- a/petprep/workflows/pet/base.py
+++ b/petprep/workflows/pet/base.py
@@ -694,7 +694,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
     ds_pet_tacs = pe.Node(
         DerivativesDataSink(
             base_directory=petprep_dir,
-            suffix='timeseries',
+            suffix='tacs',
             seg=config.workflow.seg,
             desc='preproc',
             allowed_entities=('seg',),
@@ -728,7 +728,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         ds_ref_tacs = pe.Node(
             DerivativesDataSink(
                 base_directory=petprep_dir,
-                suffix='timeseries',
+                suffix='tacs',
                 seg=config.workflow.seg,
                 desc='preproc',
                 ref=config.workflow.ref_mask_name,

--- a/petprep/workflows/pet/fit.py
+++ b/petprep/workflows/pet/fit.py
@@ -468,7 +468,7 @@ def init_pet_fit_wf(
         ds_ref_tacs = pe.Node(
             DerivativesDataSink(
                 base_directory=config.execution.petprep_dir,
-                suffix='timeseries',
+                suffix='tacs',
                 seg=config.workflow.seg,
                 desc='preproc',
                 ref=config.workflow.ref_mask_name,


### PR DESCRIPTION
Updated TAC extraction interfaces to emit _tacs.tsv files instead of _timeseries.tsv, ensuring both region-wise and reference-region outputs follow the new naming convention

Adjusted downstream workflow sinks to use the new tacs suffix, added _tacs.tsv to .bidsignore, and refreshed documentation to reference desc-preproc_tacs.tsv outputs

Updated tests to expect the new filename and to ensure the TAC workflow writes pet_resampled_tacs.tsv under the workflow directory