### PR TITLE
STY: Make use of f-strings extensive

### DIFF
--- a/.maint/update_authors.py
+++ b/.maint/update_authors.py
@@ -213,10 +213,10 @@ def zenodo(
 
     zenodo['contributors'] = [c for c in zenodo['contributors'] if c['name'] not in creator_names]
 
-    misses = set(miss_creators).intersection(miss_contributors)
-    if misses:
+    missing = {*miss_creators} & {*miss_contributors}
+    if missing:
         print(
-            f'Some people made commits, but are missing in .maint/ files: {", ".join(misses)}',
+            f'Some people made commits, but are missing in .maint/ files: {", ".join(sorted(missing))}.',
             file=sys.stderr,
         )
 
@@ -239,7 +239,7 @@ def zenodo(
         elif isinstance(creator['affiliation'], list):
             creator['affiliation'] = creator['affiliation'][0]
 
-    Path(zenodo_file).write_text('%s\n' % json.dumps(zenodo, indent=2))
+    Path(zenodo_file).write_text(f'{json.dumps(zenodo, indent=2)}\n')
 
 
 @cli.command()
@@ -287,7 +287,7 @@ def publication(
     aff_indexes = [
         ', '.join(
             [
-                '%d' % (affiliations.index(a) + 1)
+                f'{affiliations.index(a) + 1}'
                 for a in _aslist(author.get('affiliation', 'Unaffiliated'))
             ]
         )
@@ -300,21 +300,14 @@ def publication(
             file=sys.stderr,
         )
 
-    print('Authors (%d):' % len(hits))
-    print(
-        '%s.'
-        % '; '.join(
-            [
-                '{} \\ :sup:`{}`\\ '.format(i['name'], idx)
-                for i, idx in zip(hits, aff_indexes, strict=False)
-            ]
-        )
+    print(f'Authors ({len(hits)}):')
+    authors = '; '.join(
+        f'{i["name"]} \\ :sup:`{idx}`\\ ' for i, idx in zip(hits, aff_indexes, strict=False)
     )
+    print(f'{authors}.')
 
-    print(
-        '\n\nAffiliations:\n%s'
-        % '\n'.join([f'{i + 1: >2}. {a}' for i, a in enumerate(affiliations)])
-    )
+    lines = '\n'.join(f'{i + 1: >2}. {a}' for i, a in enumerate(affiliations))
+    print(f'\n\nAffiliations:\n{lines}')
 
 
 if __name__ == '__main__':

--- a/notebooks/viz/preproc.py
+++ b/notebooks/viz/preproc.py
@@ -146,7 +146,7 @@ for i, coords in enumerate([-5, 10, 20]):
     disp.add_contours(str(ATLAS_HOME / '1mm_tpm_csf.nii.gz'), colors=['k'], levels=[0.8])
     disp.add_contours(str(ATLAS_HOME / '1mm_tpm_wm.nii.gz'), colors=['w'], levels=[0.8], alpha=0.7)
     disp.add_contours(str(ATLAS_HOME / '1mm_brainmask.nii.gz'), colors=['k'], levels=[0.8], linewidths=[3], alpha=.7)
-    plt.savefig(str(out_folder / ('fmriprep-std-closeup%03d.svg' % i)), format='svg', bbox_inches='tight')
+    plt.savefig(str(out_folder / f'fmriprep-std-closeup{i:03d}.svg'), format='svg', bbox_inches='tight')
 
 for i, coords in enumerate([-5, 10, 20]):
     disp = plotting.plot_anat(str(feat_std), display_mode='z', cut_coords=[coords], cmap='viridis', threshold=30, vmin=50, vmax=170)
@@ -154,7 +154,7 @@ for i, coords in enumerate([-5, 10, 20]):
     disp.add_contours(str(ATLAS_HOME / '1mm_tpm_csf.nii.gz'), colors=['k'], levels=[0.8])
     disp.add_contours(str(ATLAS_HOME / '1mm_tpm_wm.nii.gz'), colors=['w'], levels=[0.8], alpha=0.7)
     disp.add_contours(str(ATLAS_HOME / '1mm_brainmask.nii.gz'), colors=['k'], levels=[0.8], linewidths=[3], alpha=.7)
-    plt.savefig(str(out_folder / ('feat-std-closeup%03d.svg' % i)), format='svg', bbox_inches='tight')
+    plt.savefig(str(out_folder / f'feat-std-closeup{i:03d}.svg'), format='svg', bbox_inches='tight')
 
 
 
@@ -520,15 +520,15 @@ def read_rating(fname, rater=None):
         if name == 'overall':
             data[name] = int(reportlet['rating'])
         elif '_T1w_' in name:
-            data['t1_%s' % name.split('_T1w_')[-1]] = int(reportlet['rating'])
+            data[f't1_{name.split("_T1w_")[-1]}'] = int(reportlet['rating'])
         elif '_bold_' in name:
-            repname = 'bold_%s' % name.split('_bold_')[-1]
+            repname = f'bold_{name.split("_bold_")[-1]}'
             data.setdefault(repname, []).append(int(reportlet['rating']))
         elif '_fieldmap_':
             repname = name.split('_fieldmap_')[-1]
             data.setdefault(repname, []).append(int(reportlet['rating']))
         else:
-            print('Unsupported field name "%s"' % name)
+            print(f'Unsupported field name {name}')
 
     return data
 

--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -200,9 +200,8 @@ def _build_parser(**kwargs):
         metavar='FILE',
         help='A JSON file describing custom BIDS input filters using PyBIDS. '
         'For further details, please check out '
-        'https://petprep.readthedocs.io/en/%s/faq.html#'
-        'how-do-I-select-only-certain-files-to-be-input-to-PETPrep'
-        % (currentv.base_version if is_release else 'latest'),
+        f'https://petprep.readthedocs.io/en/{currentv.base_version if is_release else "latest"}/faq.html#'
+        'how-do-I-select-only-certain-files-to-be-input-to-PETPrep',
     )
     g_bids.add_argument(
         '-d',
@@ -323,7 +322,7 @@ def _build_parser(**kwargs):
         '--output-spaces',
         nargs='*',
         action=OutputReferencesAction,
-        help="""\
+        help=f"""\
 Standard and non-standard spaces to resample anatomical and PET images to. \
 Standard spaces may be specified by the form \
 ``<SPACE>[:cohort-<label>][:res-<resolution>][...]``, where ``<SPACE>`` is \
@@ -333,8 +332,7 @@ Non-standard spaces imply specific orientations and sampling grids. \
 Important to note, the ``res-*`` modifier does not define the resolution used for \
 the spatial normalization. To generate no PET outputs, use this option without specifying \
 any spatial references. For further details, please check out \
-https://petprep.readthedocs.io/en/%s/spaces.html"""
-        % (currentv.base_version if is_release else 'latest'),
+https://petprep.readthedocs.io/en/{currentv.base_version if is_release else 'latest'}/spaces.html""",
     )
     g_conf.add_argument(
         '--longitudinal',
@@ -843,11 +841,10 @@ applied."""
 
     # Ensure input and output folders are not the same
     if output_dir == bids_dir:
+        ver = version.split('+')[0]
         parser.error(
             'The selected output folder is the same as the input BIDS folder. '
-            'Please modify the output path (suggestion: {}).'.format(
-                bids_dir / 'derivatives' / f'petprep-{version.split("+")[0]}'
-            )
+            f'Please modify the output path (suggestion: {bids_dir / "derivatives" / f"petprep-{ver}"}).'
         )
 
     if bids_dir in work_dir.parents:
@@ -886,9 +883,7 @@ applied."""
     missing_subjects = participant_label - set(all_subjects)
     if missing_subjects:
         parser.error(
-            'One or more participant labels were not found in the BIDS directory: {}.'.format(
-                ', '.join(missing_subjects)
-            )
+            f'One or more participant labels were not found in the BIDS directory: {", ".join(missing_subjects)}.'
         )
 
     config.execution.participant_label = sorted(participant_label)

--- a/petprep/cli/run.py
+++ b/petprep/cli/run.py
@@ -140,7 +140,7 @@ def main():
                 for crashfile in crashfolder.glob('crash*.*'):
                     process_crashfile(crashfile)
 
-        config.loggers.workflow.critical('PETPrep failed: %s', e)
+        config.loggers.workflow.critical(f'PETPrep failed: {e}')
         raise
     else:
         config.loggers.workflow.log(25, 'PETPrep finished successfully!')

--- a/petprep/cli/workflow.py
+++ b/petprep/cli/workflow.py
@@ -84,7 +84,7 @@ def build_workflow(config_file, retval):
 
     # Called with reports only
     if config.execution.reports_only:
-        build_log.log(25, 'Running --reports-only on participants %s', ', '.join(subject_list))
+        build_log.log(25, f'Running --reports-only on participants {", ".join(subject_list)}')
         session_list = (
             config.execution.bids_filters.get(
                 'pet', config.execution.bids_filters.get('bold', {})
@@ -101,8 +101,7 @@ def build_workflow(config_file, retval):
         )
         if failed_reports:
             config.loggers.cli.error(
-                'Report generation was not successful for the following participants : %s.',
-                ', '.join(failed_reports),
+                f'Report generation was not successful for the following participants : {", ".join(failed_reports)}.'
             )
 
         retval['return_code'] = len(failed_reports)
@@ -152,17 +151,14 @@ license file at several paths, in this order: 1) command line argument ``--fs-li
     # Check workflow for missing commands
     missing = check_deps(retval['workflow'])
     if missing:
-        build_log.critical(
-            'Cannot run PETPrep. Missing dependencies:%s',
-            '\n\t* '.join([''] + [f'{cmd} (Interface: {iface})' for iface, cmd in missing]),
-        )
+        deps_list = '\n'.join([f'\t* {cmd} (Interface: {iface})' for iface, cmd in missing])
+        build_log.critical(f'Cannot run PETPrep. Missing dependencies:\n{deps_list}')
         retval['return_code'] = 127  # 127 == command not found.
         return retval
 
     config.to_filename(config_file)
     build_log.info(
-        'PETPrep workflow graph with %d nodes built successfully.',
-        len(retval['workflow']._get_all_nodes()),
+        f'PETPrep workflow graph with {len(retval["workflow"]._get_all_nodes())} nodes built successfully.'
     )
     retval['return_code'] = 0
     return retval
@@ -217,7 +213,7 @@ def build_boilerplate(config_file, workflow):
         try:
             check_call(cmd, timeout=10)
         except (FileNotFoundError, CalledProcessError, TimeoutExpired):
-            config.loggers.cli.warning('Could not generate CITATION.html file:\n%s', ' '.join(cmd))
+            config.loggers.cli.warning(f'Could not generate CITATION.html file:\n{" ".join(cmd)}')
 
         # Generate LaTex file resolving citations
         cmd = [
@@ -234,4 +230,4 @@ def build_boilerplate(config_file, workflow):
         try:
             check_call(cmd, timeout=10)
         except (FileNotFoundError, CalledProcessError, TimeoutExpired):
-            config.loggers.cli.warning('Could not generate CITATION.tex file:\n%s', ' '.join(cmd))
+            config.loggers.cli.warning(f'Could not generate CITATION.tex file:\n{" ".join(cmd)}')

--- a/petprep/config.py
+++ b/petprep/config.py
@@ -198,7 +198,7 @@ try:
             if _proc_oc_kbytes.exists():
                 _oc_limit = _proc_oc_kbytes.read_text().strip()
             if _oc_limit in ('0', 'n/a') and Path('/proc/sys/vm/overcommit_ratio').exists():
-                _oc_limit = '{}%'.format(Path('/proc/sys/vm/overcommit_ratio').read_text().strip())
+                _oc_limit = f'{Path("/proc/sys/vm/overcommit_ratio").read_text().strip()}%'
 except Exception:  # noqa: S110, BLE001
     pass
 

--- a/petprep/workflows/base.py
+++ b/petprep/workflows/base.py
@@ -81,7 +81,7 @@ def init_petprep_wf():
                 spaces=config.workflow.spaces.get_fs_spaces(),
                 minimum_fs_version='7.0.0',
             ),
-            name='fsdir_run_{}'.format(config.execution.run_uuid.replace('-', '_')),
+            name=f'fsdir_run_{config.execution.run_uuid.replace("-", "_")}',
             run_without_submitting=True,
         )
         if config.execution.fs_subjects_dir is not None:
@@ -329,7 +329,7 @@ It is released under the [CC0]\
     # allow to run with anat-fast-track on PET-only dataset
     if 't1w_preproc' in anatomical_cache and not subject_data['t1w']:
         config.loggers.workflow.debug(
-            'No T1w image found; using precomputed T1w image: %s', anatomical_cache['t1w_preproc']
+            f'No T1w image found; using precomputed T1w image: {anatomical_cache["t1w_preproc"]}'
         )
         workflow.connect([
             (bidssrc, bids_info, [(('pet', fix_multi_T1w_source_name), 'in_file')]),

--- a/petprep/workflows/pet/base.py
+++ b/petprep/workflows/pet/base.py
@@ -172,13 +172,8 @@ def init_pet_wf(
     nvols, mem_gb = estimate_pet_mem_usage(pet_file)
 
     config.loggers.workflow.debug(
-        'Creating pet processing workflow for <%s> (%.2f GB / %d frames). '
-        'Memory resampled/largemem=%.2f/%.2f GB.',
-        pet_file,
-        mem_gb['filesize'],
-        nvols,
-        mem_gb['resampled'],
-        mem_gb['largemem'],
+        f'Creating pet processing workflow for <{pet_file}> ({mem_gb["filesize"]:.2f} GB / {nvols} frames). '
+        f'Memory resampled/largemem={mem_gb["resampled"]:.2f}/{mem_gb["largemem"]:.2f} GB.'
     )
 
     workflow = Workflow(name=_get_wf_name(pet_file, 'pet'))
@@ -834,7 +829,7 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
 
     else:
         config.loggers.workflow.warning(
-            'PET confounds will be skipped - series has only %d frame(s)', nvols
+            f'PET confounds will be skipped - series has only {nvols} frame(s)'
         )
 
     # Fill-in datasinks of reportlets seen so far

--- a/petprep/workflows/pet/fit.py
+++ b/petprep/workflows/pet/fit.py
@@ -210,10 +210,10 @@ def init_pet_fit_wf(
         config.loggers.workflow.debug('3D PET file - motion correction not needed')
     if petref:
         petref_buffer.inputs.petref = petref
-        config.loggers.workflow.debug('(Re)using motion correction reference: %s', petref)
+        config.loggers.workflow.debug(f'(Re)using motion correction reference: {petref}')
     if hmc_xforms:
         hmc_buffer.inputs.hmc_xforms = hmc_xforms
-        config.loggers.workflow.debug('(Re)using motion correction transforms: %s', hmc_xforms)
+        config.loggers.workflow.debug(f'(Re)using motion correction transforms: {hmc_xforms}')
 
     timing_parameters = prepare_timing_parameters(metadata)
     frame_durations = timing_parameters.get('FrameDuration')
@@ -405,8 +405,7 @@ def init_pet_fit_wf(
     # Stage 4: Reference mask generation
     if config.workflow.ref_mask_name:
         config.loggers.workflow.info(
-            'PET Stage 4: Generating %s reference mask',
-            config.workflow.ref_mask_name,
+            f'PET Stage 4: Generating {config.workflow.ref_mask_name} reference mask'
         )
 
         refmask_wf = init_pet_refmask_wf(

--- a/petprep/workflows/pet/resampling.py
+++ b/petprep/workflows/pet/resampling.py
@@ -121,11 +121,11 @@ def init_pet_surf_wf(
     timing_parameters = prepare_timing_parameters(metadata)
 
     workflow = Workflow(name=name)
-    workflow.__desc__ = """\
+    workflow.__desc__ = f"""\
 The PET time-series were resampled onto the following surfaces
 (FreeSurfer reconstruction nomenclature):
-{out_spaces}.
-""".format(out_spaces=', '.join([f'*{s}*' for s in surface_spaces]))
+{', '.join([f'*{s}*' for s in surface_spaces])}.
+"""
 
     inputnode = pe.Node(
         niu.IdentityInterface(


### PR DESCRIPTION
## Changes proposed in this pull request

Make use of f-strings extensive: prefer using f-strings for string interpolation and formatting instead of the modulo operator and the `str.format()` method.

f-strings have become the preferred method for Python string formatting since their introduction in Python 3.6:
https://peps.python.org/pep-0498/

The code becomes more concise and readable.

## Documentation that should be reviewed

N/A.