### PR TITLE
Add FreeSurfer seed to segmentation workflows

### DIFF
--- a/petprep/config.py
+++ b/petprep/config.py
@@ -667,6 +667,8 @@ class seeds(_Config):
     """Seed used for antsRegistration, antsAI, antsMotionCorr"""
     numpy = None
     """Seed used by NumPy"""
+    freesurfer = None
+    """Seed used by FreeSurfer utilities"""
 
     @classmethod
     def init(cls):
@@ -678,6 +680,7 @@ class seeds(_Config):
         # functions to set program specific seeds
         cls.ants = _set_ants_seed()
         cls.numpy = _set_numpy_seed()
+        cls.freesurfer = _set_freesurfer_seed()
 
 
 def _set_ants_seed():
@@ -693,6 +696,13 @@ def _set_numpy_seed():
 
     val = random.randint(1, 65536)
     np.random.seed(val)
+    return val
+
+
+def _set_freesurfer_seed():
+    """Fix random seed for FreeSurfer utilities"""
+    val = random.randint(1, 65536)
+    os.environ['FREESURFER_RANDOM_SEED'] = str(val)
     return val
 
 

--- a/petprep/interfaces/segmentation.py
+++ b/petprep/interfaces/segmentation.py
@@ -26,6 +26,7 @@ from nipype.interfaces.base import (
 from nipype.interfaces.freesurfer.base import FSCommand, FSTraitedSpec
 from nipype.interfaces.freesurfer.petsurfer import GTMSeg
 from nipype.utils.filemanip import fname_presuffix
+
 from .. import config
 
 

--- a/petprep/interfaces/tests/test_segmentation_interface.py
+++ b/petprep/interfaces/tests/test_segmentation_interface.py
@@ -1,7 +1,8 @@
 from pathlib import Path
+from types import SimpleNamespace
 
 from ... import config
-from ..segmentation import MRISclimbicSeg, SegmentBS, SegmentGTM, SegmentWM
+from ..segmentation import MRISclimbicSeg, SegmentBS, SegmentGTM, SegmentWM, _set_freesurfer_seed
 
 
 def test_segmentgtm_skip(tmp_path):
@@ -66,3 +67,12 @@ def test_segmentwm_stdout_stderr(monkeypatch, tmp_path):
     res = seg.run()
     assert res.outputs.stdout == 'wm out'
     assert res.outputs.stderr == 'wm err'
+
+
+def test_set_freesurfer_seed_runtime():
+    runtime = SimpleNamespace(environ={})
+
+    runtime = _set_freesurfer_seed(runtime)
+
+    assert runtime.environ['FREESURFER_RANDOM_SEED'] == str(config.seeds.freesurfer)
+

--- a/petprep/interfaces/tests/test_segmentation_interface.py
+++ b/petprep/interfaces/tests/test_segmentation_interface.py
@@ -16,10 +16,7 @@ def test_segmentgtm_skip(tmp_path):
 
     assert res.runtime.returncode == 0
     assert Path(res.outputs.out_file) == subj_dir / 'mri' / 'gtmseg.mgz'
-    assert (
-        res.runtime.environ['FREESURFER_RANDOM_SEED']
-        == str(config.seeds.freesurfer)
-    )
+    assert res.runtime.environ['FREESURFER_RANDOM_SEED'] == str(config.seeds.freesurfer)
 
 
 def _fake_bs_run(self, cmd):

--- a/petprep/interfaces/tests/test_segmentation_interface.py
+++ b/petprep/interfaces/tests/test_segmentation_interface.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from ... import config
-from ..segmentation import SegmentBS, SegmentGTM, SegmentWM
+from ..segmentation import MRISclimbicSeg, SegmentBS, SegmentGTM, SegmentWM
 
 
 def test_segmentgtm_skip(tmp_path):
@@ -16,6 +16,23 @@ def test_segmentgtm_skip(tmp_path):
 
     assert res.runtime.returncode == 0
     assert Path(res.outputs.out_file) == subj_dir / 'mri' / 'gtmseg.mgz'
+    assert res.runtime.environ['FREESURFER_RANDOM_SEED'] == str(config.seeds.freesurfer)
+
+
+def test_mrisclimbicseg_seed(tmp_path):
+    subjects_dir = tmp_path / 'subjects'
+    subject_dir = subjects_dir / 'sub-01'
+    subject_dir.mkdir(parents=True)
+
+    out_file = subject_dir / 'sub-01_sclimbic.nii.gz'
+    out_stats = subject_dir / 'sub-01_sclimbic.stats'
+    out_file.write_text('')
+    out_stats.write_text('')
+
+    seg = MRISclimbicSeg(out_file=str(out_file), sd=str(subjects_dir), subjects=['sub-01'])
+    res = seg.run()
+
+    assert res.runtime.returncode == 0
     assert res.runtime.environ['FREESURFER_RANDOM_SEED'] == str(config.seeds.freesurfer)
 
 

--- a/petprep/interfaces/tests/test_segmentation_interface.py
+++ b/petprep/interfaces/tests/test_segmentation_interface.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from ... import config
 from ..segmentation import SegmentBS, SegmentGTM, SegmentWM
 
 
@@ -15,6 +16,10 @@ def test_segmentgtm_skip(tmp_path):
 
     assert res.runtime.returncode == 0
     assert Path(res.outputs.out_file) == subj_dir / 'mri' / 'gtmseg.mgz'
+    assert (
+        res.runtime.environ['FREESURFER_RANDOM_SEED']
+        == str(config.seeds.freesurfer)
+    )
 
 
 def _fake_bs_run(self, cmd):

--- a/petprep/interfaces/tests/test_segmentation_interface.py
+++ b/petprep/interfaces/tests/test_segmentation_interface.py
@@ -75,4 +75,3 @@ def test_set_freesurfer_seed_runtime():
     runtime = _set_freesurfer_seed(runtime)
 
     assert runtime.environ['FREESURFER_RANDOM_SEED'] == str(config.seeds.freesurfer)
-

--- a/petprep/tests/test_config.py
+++ b/petprep/tests/test_config.py
@@ -104,9 +104,10 @@ def test_config_spaces():
 
 
 @pytest.mark.parametrize(
-    ('master_seed', 'ants_seed', 'numpy_seed'), [(1, 17612, 8272), (100, 19094, 60232)]
+    ('master_seed', 'ants_seed', 'numpy_seed', 'freesurfer_seed'),
+    [(1, 17612, 8272, 33433), (100, 19094, 60232, 59629)],
 )
-def test_prng_seed(master_seed, ants_seed, numpy_seed):
+def test_prng_seed(master_seed, ants_seed, numpy_seed, freesurfer_seed):
     """Ensure seeds are properly tracked"""
     seeds = config.seeds
     with patch.dict(os.environ, {}):
@@ -114,8 +115,10 @@ def test_prng_seed(master_seed, ants_seed, numpy_seed):
         assert seeds.master == master_seed
         assert seeds.ants == ants_seed
         assert seeds.numpy == numpy_seed
+        assert seeds.freesurfer == freesurfer_seed
         assert os.getenv('ANTS_RANDOM_SEED') == str(ants_seed)
+        assert os.getenv('FREESURFER_RANDOM_SEED') == str(freesurfer_seed)
 
     _reset_config()
-    for seed in ('_random_seed', 'master', 'ants', 'numpy'):
+    for seed in ('_random_seed', 'master', 'ants', 'numpy', 'freesurfer'):
         assert getattr(config.seeds, seed) is None


### PR DESCRIPTION
This PR addresses issue #140 by introducing a FreeSurfer-specific seeding by tracking a new freesurfer entry, initializing it alongside existing seeds, and exporting a _set_freesurfer_seed() helper that populates FREESURFER_RANDOM_SEED. Also added an internal _set_freesurfer_seed helper and invoked it in FreeSurfer-driven interfaces such as SegmentGTM to pass the seed into each command’s runtime environment.