### PR TITLE
FIX: Update TACs interface to match PET-BIDS derivatives spec

### DIFF
--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -304,8 +304,8 @@ corresponding PET time series::
 
 **Time activity curves**.
 The workflow :func:`petprep.workflows.pet.tacs.init_pet_tacs_wf` extracts mean uptake
-from an anatomical segmentation. The resulting table has ``FrameTimesStart`` and
-``FrameTimesEnd`` columns followed by one column per region::
+from an anatomical segmentation. The resulting table has ``frame_start`` and
+``frame_end`` columns followed by one column per region::
 
   sub-<subject_label>/
     pet/

--- a/petprep/interfaces/tacs.py
+++ b/petprep/interfaces/tacs.py
@@ -75,8 +75,8 @@ class ExtractTACs(SimpleInterface):
 
         frame_times_end = np.add(frame_times, frame_durations).tolist()
         df = pd.DataFrame(curves)
-        df.insert(0, 'FrameTimesEnd', frame_times_end)
-        df.insert(0, 'FrameTimesStart', list(frame_times))
+        df.insert(0, 'frame_end', frame_times_end)
+        df.insert(0, 'frame_start', list(frame_times))
 
         out_file = fname_presuffix(
             self.inputs.in_file,
@@ -133,8 +133,8 @@ class ExtractRefTAC(SimpleInterface):
         timeseries = pet_data[mask, :].mean(axis=0)
         frame_times_end = np.add(frame_times, frame_durations).tolist()
         df = pd.DataFrame({self.inputs.ref_mask_name: timeseries})
-        df.insert(0, 'FrameTimesEnd', frame_times_end)
-        df.insert(0, 'FrameTimesStart', list(frame_times))
+        df.insert(0, 'frame_end', frame_times_end)
+        df.insert(0, 'frame_start', list(frame_times))
 
         out_file = fname_presuffix(
             self.inputs.in_file,

--- a/petprep/interfaces/tests/test_tacs.py
+++ b/petprep/interfaces/tests/test_tacs.py
@@ -49,7 +49,7 @@ def test_ExtractTACs(tmp_path):
     res = node.run()
 
     out = pd.read_csv(res.outputs.out_file, sep='\t')
-    assert list(out.columns) == ['FrameTimesStart', 'FrameTimesEnd', 'A', 'B']
+    assert list(out.columns) == ['frame_start', 'frame_end', 'A', 'B']
     assert np.allclose(out['A'], [1, 2])
     assert np.allclose(out['B'], [1, 2])
 
@@ -199,7 +199,7 @@ def test_ExtractRefTAC(tmp_path):
     res = node.run()
 
     out = pd.read_csv(res.outputs.out_file, sep='\t')
-    assert list(out.columns) == ['FrameTimesStart', 'FrameTimesEnd', 'ref']
+    assert list(out.columns) == ['frame_start', 'frame_end', 'ref']
     assert np.allclose(out['ref'], [1, 2])
 
 


### PR DESCRIPTION
This PR fixes issue #145 by updating the current timing columns within the _tacs.tsv file from 'FrameTimesStart' and 'FrameTimesEnd' to 'frame_start' and 'frame_end' instead. This is also in line with the PET-BIDS derivatives specification, and also the tool 'petprep_extract_tacs.