### PR TITLE
FIX: fix thresholding to be a percentage

### DIFF
--- a/petprep/workflows/pet/hmc.py
+++ b/petprep/workflows/pet/hmc.py
@@ -271,7 +271,7 @@ FreeSurfer's ``mri_robust_template``.
         name='smooth',
         iterfield=['in_file'],
     )
-    thresh = pe.MapNode(fsl.maths.Threshold(thresh=20), name='thresh', iterfield=['in_file'])
+    thresh = pe.MapNode(fsl.maths.Threshold(thresh=20, use_robust_range=True), name='thresh', iterfield=['in_file'])
 
     # Select reference frame
     start_frame = pe.Node(


### PR DESCRIPTION
This PR addresses issue #150 by updated the thresholding to be a percentage, and not just a value. This is also in line with PETPrep_hmc. Accidentally discovered this for some data, that had been converted to SUVs, where all the values in some frames were below 20. Therefore, it gave an error. 