### PR TITLE
Fix hippocampus segmentation and labels

### DIFF
--- a/petprep/interfaces/tacs.py
+++ b/petprep/interfaces/tacs.py
@@ -113,7 +113,7 @@ class ExtractRefTAC(SimpleInterface):
         if pet_img.ndim == 3:
             pet_data = pet_data[..., np.newaxis]
 
-        mask = nb.load(self.inputs.mask_file).get_fdata() > 0
+        mask = np.rint(nb.load(self.inputs.mask_file).get_fdata()).astype(np.int16) > 0
 
         with open(self.inputs.metadata) as f:
             metadata = json.load(f)

--- a/petprep/interfaces/tacs.py
+++ b/petprep/interfaces/tacs.py
@@ -113,7 +113,7 @@ class ExtractRefTAC(SimpleInterface):
         if pet_img.ndim == 3:
             pet_data = pet_data[..., np.newaxis]
 
-        mask = np.rint(nb.load(self.inputs.mask_file).get_fdata()).astype(np.int16) > 0
+        mask = nb.load(self.inputs.mask_file).get_fdata() > 0
 
         with open(self.inputs.metadata) as f:
             metadata = json.load(f)

--- a/petprep/interfaces/tacs.py
+++ b/petprep/interfaces/tacs.py
@@ -49,7 +49,7 @@ class ExtractTACs(SimpleInterface):
         if len(frame_times) != len(frame_durations):
             raise ValueError('FrameTimesStart and FrameDuration must have equal length')
 
-        segmentation_data = np.rint(nb.load(self.inputs.segmentation).get_fdata().astype(int))
+        segmentation_data = np.rint(nb.load(self.inputs.segmentation).get_fdata()).astype(int)
         pet_data = pet_img.get_fdata()
 
         unique_labels = np.unique(segmentation_data)

--- a/petprep/interfaces/tacs.py
+++ b/petprep/interfaces/tacs.py
@@ -49,7 +49,7 @@ class ExtractTACs(SimpleInterface):
         if len(frame_times) != len(frame_durations):
             raise ValueError('FrameTimesStart and FrameDuration must have equal length')
 
-        segmentation_data = nb.load(self.inputs.segmentation).get_fdata().astype(int)
+        segmentation_data = np.rint(nb.load(self.inputs.segmentation).get_fdata().astype(int))
         pet_data = pet_img.get_fdata()
 
         unique_labels = np.unique(segmentation_data)

--- a/petprep/workflows/pet/segmentation.py
+++ b/petprep/workflows/pet/segmentation.py
@@ -55,7 +55,7 @@ def _merge_ha_labels(lh_file: str, rh_file: str) -> str:
     out_img = lh_img.__class__(data, lh_img.affine, lh_img.header)
     out_img.set_data_dtype(np.int16)
 
-    out_file = Path("hippocampusAmygdala_dseg.nii.gz").absolute()
+    out_file = Path('hippocampusAmygdala_dseg.nii.gz').absolute()
     out_img.to_filename(out_file)
     return str(out_file)
 

--- a/petprep/workflows/pet/segmentation.py
+++ b/petprep/workflows/pet/segmentation.py
@@ -48,13 +48,14 @@ def _merge_ha_labels(lh_file: str, rh_file: str) -> str:
     if not np.allclose(lh_img.affine, rh_img.affine) or lh_img.shape != rh_img.shape:
         raise ValueError('Hemisphere segmentations do not align')
 
-    lh_data = np.asanyarray(lh_img.dataobj)
-    rh_data = np.asanyarray(rh_img.dataobj)
-    data = np.where(rh_data > 0, rh_data, lh_data)
+    lh_labels = np.rint(lh_img.get_fdata()).astype(np.int16)
+    rh_labels = np.rint(rh_img.get_fdata()).astype(np.int16)
+    data = np.where(rh_labels != 0, rh_labels, lh_labels).astype(np.int16)
 
     out_img = lh_img.__class__(data, lh_img.affine, lh_img.header)
-    out_img.set_data_dtype('int16')
-    out_file = Path('hippocampusAmygdala_dseg.nii.gz').absolute()
+    out_img.set_data_dtype(np.int16)
+
+    out_file = Path("hippocampusAmygdala_dseg.nii.gz").absolute()
     out_img.to_filename(out_file)
     return str(out_file)
 


### PR DESCRIPTION
This PR addresses issue #152 causing an issue with the hippocampus segmentation. The issue was solved by loading in the data with nibabel as float, rounding it, and converting it to an integer. Then it respects the original label indices.