### PR TITLE
chore(ci): Add ref parameter to checkout action in Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           fetch-depth: 200
           fetch-tags: true
+          ref: ${{ github.ref }}
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
This should fix the spurious failure on tag builds.
