### PR TITLE
FIX: update import of segmentation data in reference mask utils

### DIFF
--- a/petprep/data/reference_mask/config.json
+++ b/petprep/data/reference_mask/config.json
@@ -5,7 +5,7 @@
     "refmask_indices": [47, 8], 
     "erode_by_voxels": 1,
     "exclude_indices": [7, 46, 172, 1007, 2007, 1009, 2009, 1011, 2011, 1013, 2013, 16], 
-    "dilate_by_voxels": 3,
+    "dilate_by_voxels": 2,
     "gm_prob_threshold": 0.8
     },
     "thalamus": 

--- a/petprep/utils/reference_mask.py
+++ b/petprep/utils/reference_mask.py
@@ -25,7 +25,7 @@ def generate_reference_region(
         nib.Nifti1Image: Final reference mask.
     """
 
-    data = seg_img.get_fdata()
+    data = np.rint(seg_img.get_fdata()).astype(int)
     affine = seg_img.affine
     header = seg_img.header
     zooms = header.get_zooms()


### PR DESCRIPTION
This PR solves issue #155 by updating the nibabel import of the segmentation file used for the reference mask workflow.