### PR TITLE
Add participant status summary log

### DIFF
--- a/petprep/cli/run.py
+++ b/petprep/cli/run.py
@@ -34,6 +34,7 @@ def main():
     from pathlib import Path
 
     from ..utils.bids import write_bidsignore, write_derivative_description
+    from ..utils.status import collect_participant_status, write_participant_log
     from .parser import parse_args
     from .workflow import build_workflow
 
@@ -200,6 +201,22 @@ def main():
             config.execution.run_uuid,
             session_list=session_list,
         )
+        participant_rows = collect_participant_status(
+            config.execution.petprep_dir,
+            config.execution.run_uuid,
+            participants=config.execution.participant_label,
+            metadata=getattr(config.execution, 'participant_data', {}),
+            failed_reports=failed_reports,
+        )
+        if participant_rows:
+            status_file = write_participant_log(
+                config.execution.petprep_dir / 'logs',
+                config.execution.run_uuid,
+                participant_rows,
+            )
+            message = f'Participant summary written to {status_file}'
+            config.loggers.workflow.log(25, message)
+            config.loggers.cli.log(25, message)
         write_derivative_description(
             config.execution.bids_dir,
             config.execution.petprep_dir,

--- a/petprep/config.py
+++ b/petprep/config.py
@@ -442,6 +442,8 @@ class execution(_Config):
     """Write out the computational graph corresponding to the planned preprocessing."""
     dataset_links = {}
     """A dictionary of dataset links to be used to track Sources in sidecars."""
+    participant_data = {}
+    """Metadata about inputs and processing state for each participant."""
 
     _layout = None
 

--- a/petprep/utils/status.py
+++ b/petprep/utils/status.py
@@ -1,0 +1,154 @@
+"""Utilities for summarizing participant processing outcomes."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+STATUS_COLUMNS = [
+    'participant',
+    'status',
+    'has_pet',
+    'has_t1w',
+    'has_native_t1w',
+    'used_derivative_t1w',
+    'n_sessions',
+    'n_pet_runs',
+    'missing_inputs',
+    'crash_files',
+    'notes',
+]
+
+
+def collect_participant_status(
+    petprep_dir: Path | str,
+    run_uuid: str,
+    *,
+    participants: Iterable[str] | None = None,
+    metadata: Mapping[str, MutableMapping[str, object]] | None = None,
+    failed_reports: Iterable[str] | None = None,
+) -> list[dict[str, str]]:
+    """Gather per-participant processing outcomes and return report rows."""
+
+    petprep_dir = Path(petprep_dir)
+    metadata = metadata or {}
+    failed = {str(label).removeprefix('sub-') for label in (failed_reports or [])}
+
+    normalized_participants: list[str] = []
+    seen: set[str] = set()
+    if participants:
+        for label in participants:
+            clean = str(label).removeprefix('sub-')
+            if clean not in seen:
+                normalized_participants.append(clean)
+                seen.add(clean)
+    else:
+        normalized_participants.extend(sorted(metadata.keys()))
+        seen.update(metadata.keys())
+
+    for label in sorted(metadata.keys()):
+        if label not in seen:
+            normalized_participants.append(label)
+            seen.add(label)
+
+    rows: list[dict[str, str]] = []
+    for label in normalized_participants:
+        record = metadata.get(label, {})
+        has_pet = _coerce_bool(record.get('has_pet'))
+        native_t1w = _coerce_bool(record.get('has_native_t1w'))
+        derivative_t1w = _coerce_bool(record.get('has_derivative_t1w'))
+        has_any_t1w = record.get('has_any_t1w')
+        if has_any_t1w is None:
+            has_any_t1w = (native_t1w is True) or (derivative_t1w is True)
+        else:
+            has_any_t1w = bool(has_any_t1w)
+
+        missing_inputs: list[str] = []
+        if has_any_t1w is False:
+            missing_inputs.append('T1w')
+        if has_pet is False and not _coerce_bool(record.get('anat_only')):
+            missing_inputs.append('PET')
+
+        crash_dir = petprep_dir / f'sub-{label}' / 'log' / run_uuid
+        crash_files = sorted(p.name for p in crash_dir.glob('crash*.*')) if crash_dir.exists() else []
+
+        status = 'completed'
+        if crash_files or label in failed:
+            status = 'failed'
+        elif missing_inputs:
+            status = 'skipped'
+
+        notes = record.get('notes') or []
+        if isinstance(notes, str):
+            notes_list = [notes]
+        else:
+            notes_list = list(notes)
+
+        row = {
+            'participant': f'sub-{label}',
+            'status': status,
+            'has_pet': _format_bool(has_pet),
+            'has_t1w': _format_bool(has_any_t1w),
+            'has_native_t1w': _format_bool(native_t1w),
+            'used_derivative_t1w': _format_bool(derivative_t1w),
+            'n_sessions': _format_int(record.get('n_sessions')),
+            'n_pet_runs': _format_int(record.get('n_pet_runs')),
+            'missing_inputs': ','.join(missing_inputs),
+            'crash_files': ','.join(crash_files),
+            'notes': '; '.join(notes_list),
+        }
+        rows.append(row)
+
+    return rows
+
+
+def write_participant_log(
+    log_dir: Path | str,
+    run_uuid: str,
+    rows: Sequence[Mapping[str, str]],
+) -> Path:
+    """Write the participant status log to disk and return the path."""
+
+    log_path = Path(log_dir)
+    log_path.mkdir(parents=True, exist_ok=True)
+    output = log_path / f'run-{run_uuid}_participant-status.tsv'
+
+    with output.open('w', newline='') as fobj:
+        writer = csv.DictWriter(fobj, fieldnames=STATUS_COLUMNS, delimiter='\t')
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({column: row.get(column, '') for column in STATUS_COLUMNS})
+
+    return output
+
+
+def _format_bool(value: bool | None) -> str:
+    if value is None:
+        return ''
+    return 'True' if value else 'False'
+
+
+def _format_int(value: object) -> str:
+    if value in (None, ''):
+        return ''
+    try:
+        return str(int(value))
+    except (TypeError, ValueError):
+        return ''
+
+
+def _coerce_bool(value: object) -> bool | None:
+    if value in (None, ''):
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if value.lower() in {'true', 'yes', '1'}:
+            return True
+        if value.lower() in {'false', 'no', '0'}:
+            return False
+    try:
+        return bool(value)
+    except Exception:  # noqa: BLE001
+        return None

--- a/petprep/utils/tests/test_status.py
+++ b/petprep/utils/tests/test_status.py
@@ -1,0 +1,65 @@
+from petprep.utils.status import collect_participant_status, write_participant_log
+
+
+def test_collect_and_write_participant_status(tmp_path):
+    run_uuid = 'test-uuid'
+
+    metadata = {
+        '01': {
+            'anat_only': False,
+            'has_pet': True,
+            'has_native_t1w': True,
+            'has_derivative_t1w': False,
+            'has_any_t1w': True,
+            'n_sessions': 2,
+            'n_pet_runs': 3,
+            'notes': [],
+        },
+        '02': {
+            'anat_only': False,
+            'has_pet': True,
+            'has_native_t1w': False,
+            'has_derivative_t1w': False,
+            'has_any_t1w': False,
+            'n_sessions': 1,
+            'n_pet_runs': 1,
+            'notes': ['Missing anatomical images'],
+        },
+        '03': {
+            'anat_only': False,
+            'has_pet': True,
+            'has_native_t1w': True,
+            'has_derivative_t1w': False,
+            'has_any_t1w': True,
+            'n_sessions': 1,
+            'n_pet_runs': 1,
+            'notes': [],
+        },
+    }
+
+    crash_dir = tmp_path / 'sub-03' / 'log' / run_uuid
+    crash_dir.mkdir(parents=True)
+    (crash_dir / 'crash-test.txt').write_text('boom')
+
+    rows = collect_participant_status(
+        tmp_path,
+        run_uuid,
+        participants=['sub-01', 'sub-02', 'sub-03'],
+        metadata=metadata,
+        failed_reports=['03'],
+    )
+
+    assert [row['participant'] for row in rows] == ['sub-01', 'sub-02', 'sub-03']
+    assert rows[0]['status'] == 'completed'
+    assert rows[1]['status'] == 'skipped'
+    assert rows[1]['missing_inputs'] == 'T1w'
+    assert rows[2]['status'] == 'failed'
+    assert 'crash-test.txt' in rows[2]['crash_files']
+
+    log_path = write_participant_log(tmp_path / 'logs', run_uuid, rows)
+
+    assert log_path.exists()
+    content = log_path.read_text().splitlines()
+    assert content[0].startswith('participant\tstatus')
+    assert any('sub-02' in line and 'skipped' in line for line in content[1:])
+    assert any('sub-03' in line and 'failed' in line for line in content[1:])

--- a/petprep/workflows/base.py
+++ b/petprep/workflows/base.py
@@ -211,6 +211,17 @@ It is released under the [CC0]\
         queries=queries,
     )[0]
 
+    participant_record = {
+        'anat_only': config.workflow.anat_only,
+        'has_pet': bool(subject_data['pet']),
+        'has_native_t1w': bool(subject_data['t1w']),
+        'has_derivative_t1w': False,
+        'has_any_t1w': bool(subject_data['t1w']),
+        'n_pet_runs': len(subject_data['pet']),
+        'notes': [],
+    }
+    config.execution.participant_data[subject_id] = participant_record
+
     if 'flair' in config.workflow.ignore:
         subject_data['flair'] = []
     if 't2w' in config.workflow.ignore:
@@ -219,6 +230,9 @@ It is released under the [CC0]\
     anat_only = config.workflow.anat_only
     # Make sure we always go through these two checks
     if not anat_only and not subject_data['pet']:
+        notes = participant_record.setdefault('notes', [])
+        if 'Missing PET images' not in notes:
+            notes.append('Missing PET images')
         raise RuntimeError(
             f'No PET images found for participant {subject_id}.All workflows require PET images.'
         )
@@ -251,6 +265,22 @@ It is released under the [CC0]\
                     std_spaces=std_spaces,
                 )
             )
+
+    notes = participant_record.setdefault('notes', [])
+    derivative_available = bool(anatomical_cache.get('t1w_preproc'))
+    participant_record['has_derivative_t1w'] = derivative_available
+    participant_record['has_any_t1w'] = bool(
+        participant_record.get('has_native_t1w') or derivative_available
+    )
+    if derivative_available and not participant_record.get('has_native_t1w'):
+        if 'Used derivative anatomical input' not in notes:
+            notes.append('Used derivative anatomical input')
+    if not participant_record['has_any_t1w']:
+        if 'Missing anatomical images' not in notes:
+            notes.append('Missing anatomical images')
+    participant_record['n_sessions'] = len(
+        config.execution.layout.get_sessions(subject=subject_id)
+    )
 
     inputnode = pe.Node(niu.IdentityInterface(fields=['subjects_dir']), name='inputnode')
 


### PR DESCRIPTION
## Summary
- capture per-participant modality availability while building subject workflows
- write a participant status TSV after report generation to highlight failures or skipped runs
- add utilities and unit tests for participant status collection and logging

## Testing
- pytest --override-ini="addopts=" petprep/utils/tests/test_status.py

------
https://chatgpt.com/codex/tasks/task_e_68ffc6b7f7a4833095a2a36a530e4b88