### PR TITLE
Add framewise displacement trace to motion report

### DIFF
--- a/petprep/data/reports-spec.yml
+++ b/petprep/data/reports-spec.yml
@@ -128,7 +128,7 @@ sections:
     subtitle: PET Summary and Carpet Plot
 
   - bids: {datatype: figures, desc: hmc, suffix: pet}
-    caption: Animated frames before and after PET head motion correction (keep cursor over image to restart).
+    caption: Animated frames before and after PET head motion correction with synchronized framewise displacement trace (keep cursor over image to restart).
     static: false
     subtitle: Motion correction
 

--- a/petprep/workflows/pet/base.py
+++ b/petprep/workflows/pet/base.py
@@ -824,6 +824,14 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             ]),
         ])  # fmt:skip
 
+        if nvols > 1:
+            workflow.connect(
+                pet_confounds_wf,
+                'outputnode.confounds_file',
+                motion_report,
+                'fd_file',
+            )
+
         if spaces.get_spaces(nonstandard=False, dim=(3,)):
             carpetplot_wf = init_carpetplot_wf(
                 mem_gb=mem_gb['resampled'],


### PR DESCRIPTION
## Summary
- extend motion report interface to accept framewise displacement values and use them when building the animation
- add a synchronized framewise displacement line plot with a marker that highlights the current frame alongside the motion-corrected views
- connect confounds outputs to the motion report and update the report caption to reflect the new visualization

## Testing
- python -m compileall petprep/interfaces/motion.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c85f010c88330923a423fe6a30687)