### PR TITLE
Add template atlas segmentation support

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -226,7 +226,7 @@ Segmentation
 ----------------
 *PETPrep* can segment the brain into different brain regions and extract time activity curves from these regions.
 The ``--seg`` flag selects the segmentation method to use.
-Available options are ``gtm`` (default) whole-brain segmentation from freesurfer, ``brainstem``, ``wm`` (white matter), ``thalamicNuclei``, ``hippocampusAmygdala``, ``raphe``, and ``limbic``.
+Available options are ``gtm`` (default) whole-brain segmentation from freesurfer, ``brainstem``, ``wm`` (white matter), ``thalamicNuclei``, ``hippocampusAmygdala``, ``raphe``, and ``limbic``. Additional atlas-based segmentations can be registered from template space by adding entries to ``petprep/data/segmentation/atlases.json`` and selecting the corresponding name with ``--seg``. When an atlas is selected, *PETPrep* automatically adds the atlas template to ``--output-spaces`` and warps the atlas and its label file into anatomical space.
 
 The ``gtm`` segmentation is a whole-brain segmentation that includes the
 cerebral cortex, subcortical structures, and cerebellum.

--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -25,6 +25,7 @@
 import sys
 
 from .. import config
+from ..utils.atlas import load_atlas_config
 
 
 def _build_parser(**kwargs):
@@ -576,20 +577,24 @@ https://petprep.readthedocs.io/en/{currentv.base_version if is_release else 'lat
         help='Disable head-motion correction and use the uncorrected data.',
     )
 
+    atlas_config = load_atlas_config()
+    seg_choices = [
+        'gtm',
+        'brainstem',
+        'thalamicNuclei',
+        'hippocampusAmygdala',
+        'wm',
+        'raphe',
+        'limbic',
+        *sorted(atlas_config.keys()),
+    ]
+
     g_seg = parser.add_argument_group('Segmentation options')
     g_seg.add_argument(
         '--seg',
         action='store',
         default='gtm',
-        choices=[
-            'gtm',
-            'brainstem',
-            'thalamicNuclei',
-            'hippocampusAmygdala',
-            'wm',
-            'raphe',
-            'limbic',
-        ],
+        choices=seg_choices,
         help='Segmentation method to use.',
     )
 
@@ -815,6 +820,17 @@ def parse_args(args=None, namespace=None):
                 Reference('T1w'),
             ],
         )
+
+    if config.workflow.seg in atlas_config:
+        atlas_spec = atlas_config[config.workflow.seg]
+        atlas_reference = atlas_spec.get('reference') or {'res': 'native'}
+        spaces = config.execution.output_spaces or SpatialReferences()
+        if not isinstance(spaces, SpatialReferences):
+            spaces = SpatialReferences(
+                [ref for s in spaces.split(' ') for ref in Reference.from_string(s)]
+            )
+        spaces.add(Reference(atlas_spec['template'], atlas_reference))
+        config.execution.output_spaces = spaces
 
     # Retrieve logging level
     build_log = config.loggers.cli

--- a/petprep/data/segmentation/atlases.json
+++ b/petprep/data/segmentation/atlases.json
@@ -1,0 +1,31 @@
+{
+  "subcortex": {
+    "template": "MNI152NLin6Asym",
+    "reference": {
+      "res": 1
+    },
+    "description": "Harvard-Oxford cortical and subcortical probabilistic atlas (thresholded).",
+    "segmentation": {
+      "source": "templateflow",
+      "query": {
+        "atlas": "HOCPA",
+        "desc": "th0",
+        "resolution": 1,
+        "suffix": "dseg",
+        "extension": [
+          ".nii.gz"
+        ]
+      }
+    },
+    "labels": {
+      "source": "templateflow",
+      "query": {
+        "atlas": "HOCPA",
+        "desc": "th0",
+        "resolution": 1,
+        "suffix": "dseg",
+        "extension": ".tsv"
+      }
+    }
+  }
+}

--- a/petprep/utils/atlas.py
+++ b/petprep/utils/atlas.py
@@ -1,0 +1,69 @@
+"""Helpers for template-driven atlas segmentations."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from importlib.resources import files as ir_files
+
+from petprep.data import load as load_data
+
+
+@lru_cache
+def load_atlas_config() -> dict[str, Any]:
+    """Load atlas configuration bundled with *PETPrep*.
+
+    The configuration maps atlas names to metadata describing the template,
+    segmentation image and corresponding label table. Both files can be
+    referenced as package data or retrieved from TemplateFlow.
+    """
+
+    config_file = ir_files('petprep.data.segmentation') / 'atlases.json'
+    return json.loads(config_file.read_text())
+
+
+def _resolve_resource(template: str, resource: dict[str, Any]) -> str:
+    """Resolve a single atlas resource to a filesystem path."""
+
+    source = resource.get('source', 'templateflow')
+    if source == 'templateflow':
+        import templateflow.api as tf
+
+        query = {**resource.get('query', {}), 'template': template}
+        result = tf.get(**query)
+        if isinstance(result, (list, tuple)):
+            if not result:
+                raise ValueError(f'No files found for atlas resource: {resource}')
+            result = result[0]
+        return str(result)
+
+    if source == 'package':
+        return str(load_data(resource['path']))
+
+    if source == 'file':
+        return str(Path(resource['path']).absolute())
+
+    raise ValueError(f"Unsupported atlas source '{source}'")
+
+
+def get_atlas_files(atlas_name: str) -> tuple[str, str]:
+    """Return the segmentation and label files for a configured atlas."""
+
+    atlas_config = load_atlas_config().get(atlas_name)
+    if atlas_config is None:
+        raise ValueError(f"Atlas '{atlas_name}' is not defined in the atlas configuration file")
+
+    segmentation = atlas_config.get('segmentation')
+    labels = atlas_config.get('labels')
+
+    if not segmentation or not labels:
+        raise ValueError(
+            f"Atlas '{atlas_name}' must define both 'segmentation' and 'labels' entries in the configuration"
+        )
+
+    seg_file = _resolve_resource(atlas_config['template'], segmentation)
+    label_file = _resolve_resource(atlas_config['template'], labels)
+    return seg_file, label_file

--- a/petprep/workflows/base.py
+++ b/petprep/workflows/base.py
@@ -537,6 +537,8 @@ It is released under the [CC0]\
                     ('outputnode.t1w_preproc', 'inputnode.t1w_preproc'),
                     ('outputnode.subjects_dir', 'inputnode.subjects_dir'),
                     ('outputnode.subject_id', 'inputnode.subject_id'),
+                    ('outputnode.template', 'inputnode.template'),
+                    ('outputnode.std2anat_xfm', 'inputnode.std2anat_xfm'),
                 ],
             ),
         ]

--- a/petprep/workflows/pet/segmentation.py
+++ b/petprep/workflows/pet/segmentation.py
@@ -4,8 +4,10 @@
 from nipype import Function
 from nipype.interfaces import utility as niu
 from nipype.interfaces.freesurfer import MRIConvert
+from nipype.interfaces.utility import KeySelect
 from nipype.pipeline import engine as pe
 from niworkflows.engine.workflows import LiterateWorkflow as Workflow
+from niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
 
 from ... import config
 from ...data import load as load_data
@@ -26,6 +28,7 @@ from ...utils.segmentation import (
     gtm_to_dsegtsv,
     summary_to_stats,
 )
+from ...utils.atlas import get_atlas_files, load_atlas_config
 
 try:  # Py>=3.9
     from importlib.resources import files as ir_files
@@ -33,6 +36,7 @@ except Exception:  # pragma: no cover - Py<3.9 fallback
     from importlib_resources import files as ir_files
 
 SEG_DATA = ir_files('petprep.data.segmentation')
+ATLAS_CONFIG = load_atlas_config()
 
 
 def _merge_ha_labels(lh_file: str, rh_file: str) -> str:
@@ -120,6 +124,13 @@ SEGMENTATIONS = {
         'color_table': str(load_data('segmentation/sclimbic_cleaned.ctab')),
     },
 }
+
+for atlas_name, atlas_spec in ATLAS_CONFIG.items():
+    SEGMENTATIONS[atlas_name] = {
+        'desc': atlas_spec.get('description', atlas_name),
+        'segstats': False,
+        'template_atlas': atlas_spec,
+    }
 
 
 def _build_nodes(
@@ -248,13 +259,60 @@ def _build_nodes(
     return nodes
 
 
+def _build_template_atlas_nodes(seg: str):
+    nodes = {}
+    nodes['seg_source'] = pe.Node(
+        niu.IdentityInterface(fields=['segmentation']), name=f'{seg}_seg_source'
+    )
+    nodes['sources'] = pe.Node(
+        BIDSURI(
+            numinputs=1,
+            dataset_links=config.execution.dataset_links,
+            out_dir=str(config.execution.petprep_dir),
+        ),
+        name='sources',
+    )
+
+    nodes['ds_seg'] = pe.Node(
+        DerivativesDataSink(
+            base_directory=config.execution.petprep_dir,
+            seg=seg,
+            allowed_entities=('seg',),
+            suffix='dseg',
+            extension='.nii.gz',
+            compress=True,
+        ),
+        name=f'ds_{seg}seg',
+        run_without_submitting=True,
+        mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+    )
+
+    nodes['ds_dseg_tsv'] = pe.Node(
+        DerivativesDataSink(
+            base_directory=config.execution.petprep_dir,
+            seg=seg,
+            allowed_entities=('seg',),
+            suffix='dseg',
+            extension='.tsv',
+            datatype='anat',
+            check_hdr=False,
+        ),
+        name=f'ds_{seg}dsegtsv',
+        run_without_submitting=True,
+        mem_gb=config.DEFAULT_MEMORY_MIN_GB,
+    )
+    return nodes
+
+
 def init_segmentation_wf(seg: str = 'gtm', name: str | None = None) -> Workflow:
     """Return a minimal segmentation workflow selecting a FreeSurfer command."""
     name = name or f'pet_{seg}_seg_wf'
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=['t1w_preproc', 'subjects_dir', 'subject_id']),
+        niu.IdentityInterface(
+            fields=['t1w_preproc', 'subjects_dir', 'subject_id', 'template', 'std2anat_xfm']
+        ),
         name='inputnode',
     )
     outputnode = pe.Node(
@@ -266,6 +324,52 @@ def init_segmentation_wf(seg: str = 'gtm', name: str | None = None) -> Workflow:
     if spec is None:
         seg_node = pe.Node(niu.IdentityInterface(fields=['segmentation']), name=f'run_{seg}')
         workflow.connect([(seg_node, outputnode, [('segmentation', 'segmentation')])])
+        return workflow
+
+    if 'template_atlas' in spec:
+        atlas_spec = spec['template_atlas']
+        atlas_nodes = _build_template_atlas_nodes(seg)
+
+        atlas_files = pe.Node(
+            niu.Function(
+                function=get_atlas_files,
+                input_names=['atlas_name'],
+                output_names=['seg_file', 'label_file'],
+            ),
+            name=f'load_{seg}_atlas',
+        )
+        atlas_files.inputs.atlas_name = seg
+
+        select_xfm = pe.Node(
+            KeySelect(fields=['std2anat_xfm'], key=atlas_spec['template']),
+            name=f'select_{seg}_xfm',
+            run_without_submitting=True,
+        )
+
+        apply_atlas = pe.Node(
+            ApplyTransforms(dimension=3, interpolation='NearestNeighbor', float=True),
+            name=f'warp_{seg}_atlas',
+        )
+
+        workflow.connect(
+            [
+                (inputnode, select_xfm, [('template', 'keys'), ('std2anat_xfm', 'std2anat_xfm')]),
+                (atlas_files, apply_atlas, [('seg_file', 'input_image')]),
+                (inputnode, apply_atlas, [('t1w_preproc', 'reference_image')]),
+                (select_xfm, apply_atlas, [('std2anat_xfm', 'transforms')]),
+                (apply_atlas, atlas_nodes['seg_source'], [('output_image', 'segmentation')]),
+                (inputnode, atlas_nodes['sources'], [('t1w_preproc', 'in1')]),
+                (atlas_nodes['seg_source'], atlas_nodes['ds_seg'], [('segmentation', 'in_file')]),
+                (inputnode, atlas_nodes['ds_seg'], [('t1w_preproc', 'source_file')]),
+                (atlas_nodes['sources'], atlas_nodes['ds_seg'], [('out', 'Sources')]),
+                (atlas_nodes['ds_seg'], outputnode, [('out_file', 'segmentation')]),
+                (atlas_files, atlas_nodes['ds_dseg_tsv'], [('label_file', 'in_file')]),
+                (inputnode, atlas_nodes['ds_dseg_tsv'], [('t1w_preproc', 'source_file')]),
+                (atlas_nodes['sources'], atlas_nodes['ds_dseg_tsv'], [('out', 'Sources')]),
+                (atlas_nodes['ds_dseg_tsv'], outputnode, [('out_file', 'dseg_tsv')]),
+            ]
+        )
+
         return workflow
 
     interface = spec['interface']


### PR DESCRIPTION
## Summary
- add a configurable atlas catalogue for template-based segmentations
- ensure atlas selections extend segmentation choices and requested output spaces
- warp configured atlases from template space into anatomy for use like existing segmentations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928215465348330a333b572960eed9b)