### PR TITLE
Fix PR 194

### DIFF
--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -789,8 +789,8 @@ def parse_args(args=None, namespace=None):
     config.execution.log_level = int(max(25 - 5 * opts.verbose_count, logging.DEBUG))
     config.from_dict(vars(opts), init=['nipype'])
 
-    config.workflow._petref_cli_set = '--petref' in argv
-    config.workflow._pet2anat_method_cli_set = '--pet2anat-method' in argv
+    config.workflow.petref_specified = '--petref' in argv
+    config.workflow.pet2anat_method_specified = '--pet2anat-method' in argv
 
     if config.execution.session_label:
         config.execution.bids_filters = config.execution.bids_filters or {}

--- a/petprep/workflows/pet/fit.py
+++ b/petprep/workflows/pet/fit.py
@@ -704,6 +704,7 @@ def init_pet_fit_wf(
         val_pet.inputs.in_file = pet_file
         if petref_strategy == 'auto':
             corrected_pet_for_report.inputs.ref_file = petref
+            petref_candidates.inputs.template = petref
             workflow.connect([
                 (val_pet, corrected_pet_for_report, [('out_file', 'in_file')]),
                 (hmc_buffer, corrected_pet_for_report, [('hmc_xforms', 'transforms')]),


### PR DESCRIPTION
I was having issues with re-running the registration step using auto: it would either not re-do the registration, or if I deleted the registration parameters, then it would fail.  This was caused by two small issues, fixed here:

  - Fix variable name mismatch in parser: use petref_specified/pet2anat_method_specified instead of
  _petref_cli_set/_pet2anat_method_cli_set
  - Add missing template petref candidate when reusing cached HMC transforms with --petref auto
