### PR TITLE
Add anatomical reference selection to reports

### DIFF
--- a/petprep/interfaces/reports.py
+++ b/petprep/interfaces/reports.py
@@ -98,6 +98,7 @@ FUNCTIONAL_TEMPLATE = """\
 \t\t<ul class="elem-desc">
 \t\t\t<li>Original orientation: {ornt}</li>
 \t\t\t<li>Registration: {registration}</li>
+\t\t\t<li>Anatomical reference: {anat_reference}</li>
 \t\t\t<li>Reference image: {reference}</li>
 \t\t\t<li>Time zero: {time_zero}</li>
 \t\t\t<li>Radiotracer: {radiotracer}</li>
@@ -247,6 +248,12 @@ class FunctionalSummaryInputSpec(TraitedSpec):
     )
     orientation = traits.Str(mandatory=True, desc='Orientation of the voxel axes')
     metadata = traits.Dict(desc='PET metadata dictionary')
+    anatref_strategy = traits.Enum(
+        't1w', 'nu', 'auto', desc='Anatomical reference used for registration'
+    )
+    requested_anatref = traits.Enum(
+        None, 't1w', 'nu', 'auto', allow_none=True, desc='Requested anatomical reference'
+    )
     petref_strategy = traits.Enum(
         'template',
         'twa',
@@ -295,6 +302,16 @@ class FunctionalSummary(SummaryInterface):
             )
         else:
             reg = f'Unknown registration method: {self.inputs.registration}'
+
+        anat_map = {
+            't1w': 'Preprocessed T1w image',
+            'nu': 'FreeSurfer bias-corrected volume (nu.mgz)',
+            'auto': 'Automatically selected anatomical reference',
+        }
+        anat_reference = anat_map.get(self.inputs.anatref_strategy, 'Unknown')
+        requested_anat = getattr(self.inputs, 'requested_anatref', None)
+        if requested_anat and requested_anat != self.inputs.anatref_strategy:
+            anat_reference += f" (requested '{requested_anat}')"
 
         reference_map = {
             'template': 'Motion correction template',
@@ -346,6 +363,7 @@ class FunctionalSummary(SummaryInterface):
 
         return FUNCTIONAL_TEMPLATE.format(
             registration=reg,
+            anat_reference=anat_reference,
             reference=petref_strategy,
             ornt=self.inputs.orientation,
             # Use the metadata dictionary to fill in the details

--- a/petprep/interfaces/tests/test_reports.py
+++ b/petprep/interfaces/tests/test_reports.py
@@ -85,6 +85,8 @@ def test_functional_summary_with_metadata(registration):
         registration=registration,
         registration_dof=6,
         orientation='RAS',
+        anatref_strategy='t1w',
+        requested_anatref='auto',
         petref_strategy='template',
         metadata={
             'TracerName': 'DASB',
@@ -99,6 +101,7 @@ def test_functional_summary_with_metadata(registration):
     segment = summary._generate_segment()
     assert registration in segment
     assert 'Reference image: Motion correction template' in segment
+    assert "Anatomical reference: Preprocessed T1w image (requested 'auto')" in segment
     assert 'Radiotracer: [11C]DASB' in segment
     assert 'Injected dose: 100 MBq' in segment
     assert 'Number of frames: 2' in segment

--- a/petprep/workflows/pet/fit.py
+++ b/petprep/workflows/pet/fit.py
@@ -649,6 +649,7 @@ def init_pet_fit_wf(
             registration_dof=config.workflow.pet2anat_dof,
             orientation=orientation,
             metadata=metadata,
+            requested_anatref=config.workflow.anatref,
             petref_strategy=petref_strategy,
             requested_petref_strategy=requested_petref_strategy,
             hmc_disabled=hmc_disabled,
@@ -872,6 +873,7 @@ def init_pet_fit_wf(
             (inputnode, select_anat_ref, [('t1w_preproc', 't1w_preproc')]),
             (nu_path, select_anat_ref, [('nu_path', 'nu_path')]),
             (detect_large_mask, select_anat_ref, [('use_nu_recommendation', 'use_nu_suggestion')]),
+            (select_anat_ref, summary, [('anatref_used', 'anatref_strategy')]),
         ]
     )  # fmt:skip
 

--- a/petprep/workflows/pet/tests/test_fit.py
+++ b/petprep/workflows/pet/tests/test_fit.py
@@ -230,6 +230,7 @@ def test_petref_default_twa_when_hmc_disabled(bids_root: Path, tmp_path: Path):
     summary = wf.get_node('summary')
     assert summary.inputs.petref_strategy == 'twa'
     assert summary.inputs.requested_petref_strategy == 'template'
+    assert summary.inputs.requested_anatref == 't1w'
     assert summary.inputs.hmc_disabled is True
 
 


### PR DESCRIPTION
## Summary
- add anatomical reference details to the functional summary HTML so auto selections are visible
- propagate the selected anatomical reference label from the workflow to reporting
- update tests to validate the new report content and configured inputs

## Testing
- python -m pytest -o addopts="" petprep/interfaces/tests/test_reports.py petprep/workflows/pet/tests/test_fit.py::test_petref_default_twa_when_hmc_disabled


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a8eddb4d4833094dd1356f96f1f56)