### PR TITLE
Use robust percentile threshold for PET reference mask

### DIFF
--- a/petprep/workflows/pet/confounds.py
+++ b/petprep/workflows/pet/confounds.py
@@ -566,7 +566,7 @@ def _binary_union(mask1, mask2):
     return str(out_name)
 
 
-def _smooth_binarize(in_file, fwhm=10.0, thresh=0.2):
+def _smooth_binarize(in_file, fwhm=10.0, thresh=20.0, use_robust_range=True):
     """Smooth ``in_file`` with a Gaussian kernel, binarize and keep largest cluster."""
     from pathlib import Path
 
@@ -579,7 +579,16 @@ def _smooth_binarize(in_file, fwhm=10.0, thresh=0.2):
     zooms = np.array(img.header.get_zooms()[:3], dtype=float)
     sigma = (fwhm / 2.3548) / zooms
     smoothed = gaussian_filter(data, sigma=sigma)
-    mask = smoothed > (thresh * smoothed.max())
+    if use_robust_range:
+        lower = np.percentile(smoothed, 2)
+        upper = np.percentile(smoothed, 98)
+        threshold = lower + (thresh / 100.0) * (upper - lower)
+        # Fall back to max-based thresholding if the robust range collapses
+        if upper <= lower:
+            threshold = thresh * smoothed.max()
+    else:
+        threshold = thresh * smoothed.max()
+    mask = smoothed > threshold
 
     labeled, n_labels = label(mask)
     if n_labels > 1:

--- a/petprep/workflows/pet/fit.py
+++ b/petprep/workflows/pet/fit.py
@@ -866,7 +866,8 @@ def init_pet_fit_wf(
 
     petref_mask = pe.Node(niu.Function(function=_smooth_binarize), name='petref_mask')
     petref_mask.inputs.fwhm = 10.0
-    petref_mask.inputs.thresh = 0.2
+    petref_mask.inputs.thresh = 20.0
+    petref_mask.inputs.use_robust_range = True
 
     detect_large_mask = pe.Node(
         niu.Function(

--- a/petprep/workflows/pet/tests/test_smooth_binarize.py
+++ b/petprep/workflows/pet/tests/test_smooth_binarize.py
@@ -13,7 +13,7 @@ def test_smooth_binarize_largest(tmp_path):
     src = tmp_path / 'input.nii.gz'
     img.to_filename(src)
 
-    out = _smooth_binarize(str(src), fwhm=0.0, thresh=0.5)
+    out = _smooth_binarize(str(src), fwhm=0.0, thresh=50.0)
     result = nb.load(out).get_fdata()
     _, num = label(result > 0)
     assert num == 1


### PR DESCRIPTION
## Summary
- use a robust percentile-based threshold when smoothing and binarizing the PET reference for mask generation
- align the PET brain mask workflow inputs with the robust thresholding used in HMC workflows
- update the PET mask unit test to exercise the percentile-based behavior

## Testing
- python -m pytest --override-ini addopts="" petprep/workflows/pet/tests/test_smooth_binarize.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69430bfbed5883309f3413876e17332a)