### PR TITLE
Add run label selection to CLI

### DIFF
--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -96,6 +96,11 @@ def _build_parser(**kwargs):
         """Parse an integer value or the special 'auto' keyword."""
         return 'auto' if value == 'auto' else int(value)
 
+    def _run_label(value):
+        """Normalize run labels, allowing both run-01 and 1 forms."""
+        value = value.removeprefix('run-')
+        return int(value) if value.isdigit() else value
+
     def _to_gb(value):
         scale = {'G': 1, 'T': 10**3, 'M': 1e-3, 'K': 1e-6, 'B': 1e-9}
         digits = ''.join([c for c in value if c.isdigit()])
@@ -201,6 +206,13 @@ def _build_parser(**kwargs):
         type=lambda label: label.removeprefix('trc-'),
         help='A space delimited list of tracer identifiers or a single '
         'identifier (the trc- prefix can be removed)',
+    )
+    g_bids.add_argument(
+        '--run-label',
+        nargs='+',
+        type=_run_label,
+        help='A space delimited list of run identifiers or a single identifier '
+        '(the run- prefix can be removed)',
     )
     # Re-enable when option is actually implemented
     # g_bids.add_argument('-r', '--run-id', action='store', default='single_run',
@@ -828,6 +840,13 @@ def parse_args(args=None, namespace=None):
             'tracer': config.execution.tracer_label,
         }
 
+    if config.execution.run_label:
+        config.execution.bids_filters = config.execution.bids_filters or {}
+        config.execution.bids_filters['pet'] = {
+            **config.execution.bids_filters.get('pet', {}),
+            'run': config.execution.run_label,
+        }
+
     pvc_vals = (opts.pvc_tool, opts.pvc_method, opts.pvc_psf)
     if any(val is not None for val in pvc_vals) and not all(val is not None for val in pvc_vals):
         parser.error('Options --pvc-tool, --pvc-method and --pvc-psf must be used together.')
@@ -1017,6 +1036,28 @@ applied."""
                 'One or more tracer labels were not found in the BIDS directory: '
                 f'{", ".join(sorted(missing_tracers))}.'
             )
+
+    if config.execution.run_label:
+        run_filters = (
+            config.execution.bids_filters.get('pet', {}) if config.execution.bids_filters else {}
+        )
+        run_filters = {key: value for key, value in run_filters.items() if key != 'run'}
+        available_runs = set(
+            config.execution.layout.get_runs(
+                subject=list(participant_label) or None,
+                **run_filters,
+            )
+        )
+        missing_runs = set(config.execution.run_label) - available_runs
+        if missing_runs:
+            parser.error(
+                'One or more run labels were not found in the BIDS directory: '
+                f'{", ".join(sorted(map(str, missing_runs)))}.'
+            )
+
+    if config.execution.run_label:
+        config.execution.run_label = sorted(set(config.execution.run_label))
+        config.execution.bids_filters['pet']['run'] = config.execution.run_label
 
     config.execution.participant_label = sorted(participant_label)
     config.workflow.skull_strip_template = config.workflow.skull_strip_template[0]

--- a/petprep/cli/tests/test_parser.py
+++ b/petprep/cli/tests/test_parser.py
@@ -336,6 +336,76 @@ def test_tracer_label_validation(tmp_path):
     _reset_config()
 
 
+def test_run_label_only_filters_pet(tmp_path):
+    bids = tmp_path / 'bids'
+    out_dir = tmp_path / 'out'
+    work_dir = tmp_path / 'work'
+    bids.mkdir()
+    (bids / 'dataset_description.json').write_text('{"Name": "Test", "BIDSVersion": "1.8.0"}')
+
+    anat_path = bids / 'sub-01' / 'anat' / 'sub-01_T1w.nii.gz'
+    anat_path.parent.mkdir(parents=True, exist_ok=True)
+    nb.Nifti1Image(np.zeros((5, 5, 5)), np.eye(4)).to_filename(anat_path)
+
+    pet_path = bids / 'sub-01' / 'pet' / 'sub-01_run-01_pet.nii.gz'
+    pet_path.parent.mkdir(parents=True, exist_ok=True)
+    nb.Nifti1Image(np.zeros((5, 5, 5, 1)), np.eye(4)).to_filename(pet_path)
+    (pet_path.with_suffix('').with_suffix('.json')).write_text(
+        '{"FrameTimesStart": [0], "FrameDuration": [1]}'
+    )
+
+    try:
+        parse_args(
+            args=[
+                str(bids),
+                str(out_dir),
+                'participant',
+                '--run-label',
+                '01',
+                '--skip-bids-validation',
+                '-w',
+                str(work_dir),
+            ]
+        )
+
+        filters = config.execution.bids_filters
+        assert filters.get('pet', {}).get('run') == [1]
+        assert 'run' not in filters.get('anat', {})
+    finally:
+        _reset_config()
+
+
+def test_run_label_validation(tmp_path):
+    bids = tmp_path / 'bids'
+    out_dir = tmp_path / 'out'
+    work_dir = tmp_path / 'work'
+    bids.mkdir()
+    (bids / 'dataset_description.json').write_text('{"Name": "Test", "BIDSVersion": "1.8.0"}')
+
+    pet_path = bids / 'sub-01' / 'pet' / 'sub-01_run-01_pet.nii.gz'
+    pet_path.parent.mkdir(parents=True, exist_ok=True)
+    nb.Nifti1Image(np.zeros((5, 5, 5, 1)), np.eye(4)).to_filename(pet_path)
+    (pet_path.with_suffix('').with_suffix('.json')).write_text(
+        '{"FrameTimesStart": [0], "FrameDuration": [1]}'
+    )
+
+    with pytest.raises(SystemExit):
+        parse_args(
+            args=[
+                str(bids),
+                str(out_dir),
+                'participant',
+                '--run-label',
+                '2',
+                '--skip-bids-validation',
+                '-w',
+                str(work_dir),
+            ]
+        )
+
+    _reset_config()
+
+
 def test_pvc_argument_handling(tmp_path, minimal_bids):
     out_dir = tmp_path / 'out'
     work_dir = tmp_path / 'work'

--- a/petprep/config.py
+++ b/petprep/config.py
@@ -436,6 +436,8 @@ class execution(_Config):
     """List of session identifiers that are to be preprocessed."""
     tracer_label = None
     """List of tracer identifiers that are to be preprocessed."""
+    run_label = None
+    """List of run identifiers that are to be preprocessed."""
     task_id = None
     """Select a particular task from all available in the dataset."""
     templateflow_home = _templateflow_home
@@ -517,7 +519,7 @@ class execution(_Config):
                 else:
                     return (
                         getattr(Query, value[7:-4])
-                        if not isinstance(value, Query) and 'Query' in value
+                        if isinstance(value, str) and not isinstance(value, Query) and 'Query' in value
                         else value
                     )
 


### PR DESCRIPTION
## Summary
- add a `--run-label` CLI option to select specific runs alongside existing participant/session flags
- propagate run selections into BIDS filters with validation against available runs
- cover run-label parsing and validation, including leading-zero inputs

## Testing
- pytest petprep/cli/tests/test_parser.py::test_run_label_only_filters_pet petprep/cli/tests/test_parser.py::test_run_label_validation

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942ce1e0af88330baf032e3ddb4a84b)