### PR TITLE
Crop PET reference prior to registration

### DIFF
--- a/petprep/interfaces/cropping.py
+++ b/petprep/interfaces/cropping.py
@@ -1,0 +1,146 @@
+"""Interfaces for cropping PET images."""
+
+from __future__ import annotations
+
+import numpy as np
+from nipype.interfaces.base import File, SimpleInterface, TraitedSpec, Undefined, traits
+from nipype.utils.filemanip import fname_presuffix
+
+
+def _voxel_size_z_mm(aff: np.ndarray) -> float:
+    return float(np.linalg.norm(aff[:3, 2]))
+
+
+def _k_increases_to_superior(aff: np.ndarray) -> bool:
+    """
+    Determine whether increasing k (z index) moves toward +Superior in world coords.
+
+    We use the affine's 3rd column (voxel k-axis direction in world), and look at its
+    world-Z component (RAS+ or LPS+ both have Superior as +Z in nibabel world).
+    """
+    k_dir_world = aff[:3, 2]
+    return float(k_dir_world[2]) > 0
+
+
+def _find_head_start_slice(mask3d: np.ndarray, from_superior: bool, min_vox_per_slice: int) -> int:
+    """
+    Find first slice index (k) from the superior end that contains >= min_vox_per_slice mask voxels.
+    Returns the slice index in original k coordinates.
+    """
+    area = mask3d.sum(axis=(0, 1)).astype(np.int64)
+    z_len = area.size
+
+    if from_superior:
+        for kk in range(z_len - 1, -1, -1):
+            if area[kk] >= min_vox_per_slice:
+                return kk
+    else:
+        for kk in range(0, z_len):
+            if area[kk] >= min_vox_per_slice:
+                return kk
+
+    raise ValueError("No slice meets min_vox_per_slice; mask might be empty or too thin.")
+
+
+class CropPetFromHeadFixedZInputSpec(TraitedSpec):
+    """Input specification for :class:`CropPetFromHeadFixedZ`."""
+
+    in_file = File(exists=True, mandatory=True, desc='Input PET NIfTI (3D or 4D)')
+    mask_file = File(exists=True, mandatory=True, desc='Mask aligned to the PET grid (3D)')
+    z_mm = traits.Float(200.0, usedefault=True, desc='Fixed z-extent to retain, in millimeters')
+    pad_mm = traits.Float(20.0, usedefault=True, desc='Padding applied to both ends, in millimeters')
+    min_vox_per_slice = traits.Int(
+        50,
+        usedefault=True,
+        desc='Minimum mask voxels per slice to define the superior head slice',
+    )
+    out_file = File(desc='Output cropped PET image')
+    out_mask = File(desc='Optional output cropped mask')
+
+
+class CropPetFromHeadFixedZOutputSpec(TraitedSpec):
+    """Output specification for :class:`CropPetFromHeadFixedZ`."""
+
+    out_file = File(exists=True, desc='Cropped PET image')
+    out_mask = File(desc='Cropped mask (if requested)', allow_none=True)
+
+
+class CropPetFromHeadFixedZ(SimpleInterface):
+    """Crop a PET image in the superior-inferior direction."""
+
+    input_spec = CropPetFromHeadFixedZInputSpec
+    output_spec = CropPetFromHeadFixedZOutputSpec
+
+    def _run_interface(self, runtime):
+        import nibabel as nb
+
+        pet_img = nb.load(self.inputs.in_file)
+        pet_data = np.asanyarray(pet_img.dataobj)
+        if pet_data.ndim not in (3, 4):
+            raise ValueError(f"PET must be 3D or 4D, got shape {pet_data.shape}")
+
+        mask_img = nb.load(self.inputs.mask_file)
+        mask3d = np.asanyarray(mask_img.dataobj).astype(np.uint8) > 0
+        if mask3d.ndim != 3:
+            raise ValueError("Mask must be 3D")
+        if mask3d.shape != pet_img.shape[:3]:
+            raise ValueError(
+                f"Mask shape {mask3d.shape} does not match PET spatial shape {pet_img.shape[:3]}"
+            )
+
+        aff = pet_img.affine
+        vz = _voxel_size_z_mm(aff)
+        k_to_sup = _k_increases_to_superior(aff)
+        superior_is_high_k = k_to_sup
+        head_k = _find_head_start_slice(
+            mask3d, from_superior=superior_is_high_k, min_vox_per_slice=self.inputs.min_vox_per_slice
+        )
+
+        nz = int(np.round(self.inputs.z_mm / vz))
+        pad = int(np.ceil(self.inputs.pad_mm / vz)) if self.inputs.pad_mm > 0 else 0
+        z_len = pet_img.shape[2]
+
+        if superior_is_high_k:
+            z1 = head_k + 1 + pad
+            z0 = z1 - (nz + 2 * pad)
+        else:
+            z0 = head_k - pad
+            z1 = z0 + (nz + 2 * pad)
+
+        z0 = max(0, z0)
+        z1 = min(z_len, z1)
+        if z1 <= z0 + 1:
+            raise ValueError(f"Computed invalid crop: z0={z0}, z1={z1}, Z={z_len}")
+
+        aff2 = aff.copy()
+        aff2[:3, 3] = aff[:3, 3] + aff[:3, 2] * float(z0)
+
+        if pet_data.ndim == 3:
+            pet_out_data = np.asarray(pet_data[:, :, z0:z1], dtype=np.float32)
+        else:
+            pet_out_data = np.asarray(pet_data[:, :, z0:z1, :], dtype=np.float32)
+
+        pet_hdr2 = pet_img.header.copy()
+        pet_hdr2.set_data_shape(pet_out_data.shape)
+        pet_out_img = pet_img.__class__(pet_out_data, aff2, header=pet_hdr2)
+
+        out_file = self.inputs.out_file
+        if not out_file:
+            out_file = fname_presuffix(self.inputs.in_file, suffix='_zcrop', newpath=runtime.cwd)
+        pet_out_img.to_filename(out_file)
+        self._results['out_file'] = out_file
+
+        out_mask_path = None
+        if self.inputs.out_mask:
+            mask_out_data = mask3d[:, :, z0:z1].astype(np.uint8)
+            mask_out_img = mask_img.__class__(mask_out_data, aff2)
+            mask_out_img.set_data_dtype(np.uint8)
+            mask_out_img.header['scl_slope'] = 1
+            mask_out_img.header['scl_inter'] = 0
+            mask_out_img.header['cal_min'] = 0
+            mask_out_img.header['cal_max'] = 1
+            mask_out_img.to_filename(self.inputs.out_mask)
+            out_mask_path = self.inputs.out_mask
+
+        self._results['out_mask'] = out_mask_path if out_mask_path is not None else Undefined
+        return runtime

--- a/petprep/interfaces/tests/test_cropping.py
+++ b/petprep/interfaces/tests/test_cropping.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import nibabel as nb
+import numpy as np
+
+from petprep.interfaces.cropping import CropPetFromHeadFixedZ
+
+
+def test_crop_pet_from_head_superior_high_k(tmp_path: Path):
+    """Cropping should trim slices inferior to the head when k increases superiorly."""
+
+    data = np.stack([np.full((2, 2), fill_value=z, dtype=np.float32) for z in range(6)], axis=-1)
+    pet_img = nb.Nifti1Image(data, np.diag([2.0, 2.0, 2.0, 1.0]))
+    pet_file = tmp_path / 'pet.nii.gz'
+    pet_img.to_filename(pet_file)
+
+    mask = np.zeros((2, 2, 6), dtype=np.uint8)
+    mask[..., 4:] = 1
+    mask_file = tmp_path / 'mask.nii.gz'
+    nb.Nifti1Image(mask, pet_img.affine).to_filename(mask_file)
+
+    result = CropPetFromHeadFixedZ(
+        in_file=str(pet_file),
+        mask_file=str(mask_file),
+        z_mm=4.0,
+        pad_mm=0.0,
+        min_vox_per_slice=1,
+    ).run()
+
+    cropped = nb.load(result.outputs.out_file)
+    assert cropped.shape == (2, 2, 2)
+    assert np.allclose(cropped.get_fdata(), data[..., 4:])
+    assert np.allclose(cropped.affine[:3, 3], [0.0, 0.0, 8.0])
+
+
+def test_crop_pet_from_head_superior_low_k(tmp_path: Path):
+    """Cropping should handle grids where superior is at low k indices."""
+
+    data = np.stack([np.full((2, 2), fill_value=z, dtype=np.float32) for z in range(6)], axis=-1)
+    # Flip z axis to make superior correspond to low k
+    affine = np.diag([2.0, 2.0, -2.0, 1.0])
+    pet_img = nb.Nifti1Image(data, affine)
+    pet_file = tmp_path / 'pet_inferior.nii.gz'
+    pet_img.to_filename(pet_file)
+
+    mask = np.zeros((2, 2, 6), dtype=np.uint8)
+    mask[..., :2] = 1
+    mask_file = tmp_path / 'mask_inferior.nii.gz'
+    nb.Nifti1Image(mask, affine).to_filename(mask_file)
+
+    out_mask = tmp_path / 'mask_crop.nii.gz'
+    result = CropPetFromHeadFixedZ(
+        in_file=str(pet_file),
+        mask_file=str(mask_file),
+        z_mm=4.0,
+        pad_mm=0.0,
+        min_vox_per_slice=1,
+        out_mask=str(out_mask),
+    ).run()
+
+    cropped = nb.load(result.outputs.out_file)
+    assert cropped.shape == (2, 2, 2)
+    assert np.allclose(cropped.get_fdata(), data[..., :2])
+    assert np.allclose(cropped.affine[:3, 3], [0.0, 0.0, 0.0])
+
+    cropped_mask = nb.load(result.outputs.out_mask)
+    assert cropped_mask.shape == (2, 2, 2)
+    assert np.array_equal(cropped_mask.get_fdata(), mask[..., :2])

--- a/petprep/workflows/pet/fit.py
+++ b/petprep/workflows/pet/fit.py
@@ -987,6 +987,7 @@ def init_pet_fit_wf(
                         ('t1w_preproc', 'inputnode.anat_preproc'),
                         ('t1w_mask', 'inputnode.anat_mask'),
                     ]),
+                    (petref_mask, reg_wf, [('out', 'inputnode.ref_pet_mask')]),
                     (petref_candidates, reg_wf, [(label, 'inputnode.ref_pet_brain')]),
                     (reg_wf, score_merge, [(
                         'outputnode.registration_score', f'in{idx + 1}'
@@ -1062,6 +1063,7 @@ def init_pet_fit_wf(
                     ('t1w_preproc', 'inputnode.anat_preproc'),
                     ('t1w_mask', 'inputnode.anat_mask'),
                 ]),
+                (petref_mask, pet_reg_wf, [('out', 'inputnode.ref_pet_mask')]),
                 (petref_buffer, pet_reg_wf, [('petref', 'inputnode.ref_pet_brain')]),
                 (val_pet, ds_petreg_wf, [('out_file', 'inputnode.source_files')]),
                 (pet_reg_wf, ds_petreg_wf, [('outputnode.itk_pet_to_t1', 'inputnode.xform')]),

--- a/petprep/workflows/pet/registration.py
+++ b/petprep/workflows/pet/registration.py
@@ -34,6 +34,7 @@ from nipype.interfaces import utility as niu
 from nipype.pipeline import engine as pe
 
 from petprep import config
+from ...interfaces.cropping import CropPetFromHeadFixedZ
 
 AffineDOF = ty.Literal[6, 9, 12]
 
@@ -100,6 +101,8 @@ def init_pet_reg_wf(
     ref_pet_brain
         Reference image to which PET series is aligned
         If ``fieldwarp == True``, ``ref_pet_brain`` should be unwarped
+    ref_pet_mask
+        Mask of the reference PET image, used to crop the field-of-view
     anat_preproc
         Preprocessed anatomical image
     anat_mask
@@ -125,7 +128,7 @@ def init_pet_reg_wf(
 
     workflow = Workflow(name=name)
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=['ref_pet_brain', 'anat_preproc', 'anat_mask']),
+        niu.IdentityInterface(fields=['ref_pet_brain', 'ref_pet_mask', 'anat_preproc', 'anat_mask']),
         name='inputnode',
     )
 
@@ -142,6 +145,9 @@ def init_pet_reg_wf(
     mask_brain = pe.Node(ApplyMask(), name='mask_brain')
     crop_anat_mask = pe.Node(MRIConvert(out_type='niigz'), name='crop_anat_mask')
     robust_fov = pe.Node(RobustFOV(output_type='NIFTI_GZ'), name='robust_fov')
+    crop_ref_pet = pe.Node(
+        CropPetFromHeadFixedZ(z_mm=200.0, pad_mm=20.0), name='crop_ref_pet', mem_gb=0.1
+    )
 
     if pet2anat_method == 'auto':
         ants_coreg = pe.Node(
@@ -224,12 +230,13 @@ def init_pet_reg_wf(
                 (robust_fov, crop_anat_mask, [('out_roi', 'reslice_like')]),
                 (robust_fov, mask_brain, [('out_roi', 'in_file')]),
                 (crop_anat_mask, mask_brain, [('out_file', 'in_mask')]),
+                (inputnode, crop_ref_pet, [('ref_pet_brain', 'in_file'), ('ref_pet_mask', 'mask_file')]),
                 # ANTs branch
-                (inputnode, ants_coreg, [('ref_pet_brain', 'moving_image')]),
+                (crop_ref_pet, ants_coreg, [('out_file', 'moving_image')]),
                 (robust_fov, ants_coreg, [('out_roi', 'fixed_image')]),
                 (crop_anat_mask, ants_coreg, [('out_file', 'fixed_image_masks')]),
                 (ants_coreg, ants_convert, [(('forward_transforms', _get_first), 'in_xfms')]),
-                (inputnode, ants_warp, [('ref_pet_brain', 'input_image')]),
+                (crop_ref_pet, ants_warp, [('out_file', 'input_image')]),
                 (robust_fov, ants_warp, [('out_roi', 'reference_image')]),
                 (ants_convert, ants_warp, [('out_xfm', 'transforms')]),
                 (ants_warp, ants_score, [('output_image', 'moving_image')]),
@@ -237,10 +244,10 @@ def init_pet_reg_wf(
                 (crop_anat_mask, ants_score, [('out_file', 'fixed_image_mask')]),
                 (crop_anat_mask, ants_score, [('out_file', 'moving_image_mask')]),
                 # FreeSurfer branch
-                (inputnode, fs_coreg, [('ref_pet_brain', 'source_file')]),
+                (crop_ref_pet, fs_coreg, [('out_file', 'source_file')]),
                 (mask_brain, fs_coreg, [('out_file', 'reference_file')]),
                 (fs_coreg, fs_convert, [('out_lta_file', 'in_xfms')]),
-                (inputnode, fs_warp, [('ref_pet_brain', 'input_image')]),
+                (crop_ref_pet, fs_warp, [('out_file', 'input_image')]),
                 (mask_brain, fs_warp, [('out_file', 'reference_image')]),
                 (fs_convert, fs_warp, [('out_xfm', 'transforms')]),
                 (fs_warp, fs_score, [('output_image', 'moving_image')]),
@@ -351,7 +358,8 @@ def init_pet_reg_wf(
         connections = [
             (robust_fov, mask_brain, [('out_roi', 'in_file')]),
             (crop_anat_mask, mask_brain, [('out_file', 'in_mask')]),
-            (inputnode, coreg, [('ref_pet_brain', coreg_moving)]),
+            (inputnode, crop_ref_pet, [('ref_pet_brain', 'in_file'), ('ref_pet_mask', 'mask_file')]),
+            (crop_ref_pet, coreg, [('out_file', coreg_moving)]),
             (
                 robust_fov,
                 coreg,
@@ -369,7 +377,7 @@ def init_pet_reg_wf(
                     ('out_inv', 'itk_t1_to_pet'),
                 ],
             ),
-            (inputnode, warp_for_score, [('ref_pet_brain', 'input_image')]),
+            (crop_ref_pet, warp_for_score, [('out_file', 'input_image')]),
             (robust_fov, warp_for_score, [('out_roi', 'reference_image')]),
             (convert_xfm, warp_for_score, [('out_xfm', 'transforms')]),
             (warp_for_score, similarity, [('output_image', 'moving_image')]),
@@ -383,7 +391,8 @@ def init_pet_reg_wf(
         connections = [
             (robust_fov, mask_brain, [('out_roi', 'in_file')]),
             (crop_anat_mask, mask_brain, [('out_file', 'in_mask')]),
-            (inputnode, coreg, [('ref_pet_brain', coreg_moving)]),
+            (inputnode, crop_ref_pet, [('ref_pet_brain', 'in_file'), ('ref_pet_mask', 'mask_file')]),
+            (crop_ref_pet, coreg, [('out_file', coreg_moving)]),
             (mask_brain, coreg, [('out_file', coreg_target)]),
             (coreg, convert_xfm, [(coreg_output, 'in_xfms')]),
             (
@@ -394,7 +403,7 @@ def init_pet_reg_wf(
                     ('out_inv', 'itk_t1_to_pet'),
                 ],
             ),
-            (inputnode, warp_for_score, [('ref_pet_brain', 'input_image')]),
+            (crop_ref_pet, warp_for_score, [('out_file', 'input_image')]),
             (robust_fov, warp_for_score, [('out_roi', 'reference_image')]),
             (convert_xfm, warp_for_score, [('out_xfm', 'transforms')]),
             (warp_for_score, similarity, [('output_image', 'moving_image')]),


### PR DESCRIPTION
## Summary
- add a PET head cropping interface to trim the superior-inferior extent with configurable padding
- run the crop within the PET-to-anatomy registration workflow using the PET mask input and pass the cropped image to all coregistration branches
- connect the PET mask into registration wiring and add targeted tests for the crop logic

## Testing
- pytest --override-ini="addopts=" petprep/interfaces/tests/test_cropping.py
- pytest --override-ini="addopts=" petprep/workflows/pet/tests/test_fit.py::test_init_pet_fit_wf_auto_registration

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943cfaeca6483309111875875ff0489)