### PR TITLE
Add option to combine PET runs before preprocessing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Bug-fix release in the 0.0.x series.
 * FIX: fix thresholding to be a percentage (#151)
 * FIX: Update TACs interface to match PET-BIDS derivatives spec (#146)
 * ENH: Create morph refmask and derivatives (#143)
+* ENH: Add ``--combine-runs`` option to merge PET acquisitions prior to preprocessing (#xxx)
 * DOC: Fix the path to the `sample_report` folder in the output doc (#97)
 * DOC: Add preliminary release to "What is new" page (#103)
 * REF: Remove unused parameters from PET confound workflow initialization (#107)

--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -214,6 +214,12 @@ def _build_parser(**kwargs):
         help='A space delimited list of run identifiers or a single identifier '
         '(the run- prefix can be removed)',
     )
+    g_bids.add_argument(
+        '--combine-runs',
+        action='store_true',
+        help='Concatenate PET runs within each session before preprocessing. '
+        'Combined files omit the run entity.',
+    )
     # Re-enable when option is actually implemented
     # g_bids.add_argument('-r', '--run-id', action='store', default='single_run',
     #                     help='Select a specific run to be processed')
@@ -1061,3 +1067,29 @@ applied."""
 
     config.execution.participant_label = sorted(participant_label)
     config.workflow.skull_strip_template = config.workflow.skull_strip_template[0]
+
+    if config.execution.combine_runs:
+        from ..utils.bids import combine_pet_runs
+
+        build_log.info('Combining PET runs prior to preprocessing')
+        combined_dir, combined_files = combine_pet_runs(
+            bids_dir=bids_dir,
+            layout=config.execution.layout,
+            work_dir=config.execution.work_dir / config.execution.run_uuid,
+            subjects=config.execution.participant_label,
+            bids_filters=config.execution.bids_filters or {},
+        )
+
+        if not combined_files:
+            build_log.warning('No PET runs found to combine; proceeding with original inputs.')
+        else:
+            build_log.info(f'Combined {len(combined_files)} PET file(s) into run-less series.')
+
+        config.execution.bids_dir = combined_dir
+        config.execution.bids_database_dir = config.execution.work_dir / config.execution.run_uuid / 'combined_bids_db'
+        config.execution._layout = None
+        config.execution.layout = None
+        config.execution.init()
+        if config.execution.bids_filters and 'pet' in config.execution.bids_filters:
+            config.execution.bids_filters['pet'].pop('run', None)
+        config.execution.run_label = None

--- a/petprep/config.py
+++ b/petprep/config.py
@@ -438,6 +438,8 @@ class execution(_Config):
     """List of tracer identifiers that are to be preprocessed."""
     run_label = None
     """List of run identifiers that are to be preprocessed."""
+    combine_runs = False
+    """Combine multiple runs for each PET series before preprocessing."""
     task_id = None
     """Select a particular task from all available in the dataset."""
     templateflow_home = _templateflow_home

--- a/petprep/utils/bids.py
+++ b/petprep/utils/bids.py
@@ -26,10 +26,12 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from collections import defaultdict
 from functools import cache
 from pathlib import Path
+from shutil import copytree, rmtree
 
 from bids.layout import BIDSLayout
 from bids.utils import listify
@@ -165,6 +167,110 @@ def write_derivative_description(bids_dir, deriv_dir, dataset_links=None):
             desc['DatasetLinks']['templateflow'] = 'https://github.com/templateflow/templateflow'
 
     Path.write_text(deriv_dir / 'dataset_description.json', json.dumps(desc, indent=4))
+
+
+def _ignore_run_pet_files(_, names):
+    run_pet = []
+    for name in names:
+        if '_run-' not in name:
+            continue
+        if name.endswith('_pet.nii.gz') or name.endswith('_pet.nii') or name.endswith('_pet.json'):
+            run_pet.append(name)
+    return run_pet
+
+
+def _merge_frame_metadata(metas: list[dict]) -> dict:
+    merged = metas[0].copy()
+    frame_times = []
+    frame_durations = []
+    offset = 0.0
+
+    for meta in metas:
+        starts = meta.get('FrameTimesStart') or []
+        durations = meta.get('FrameDuration') or []
+
+        if starts:
+            frame_times.extend([float(start) + offset for start in starts])
+        if durations:
+            frame_durations.extend(durations)
+
+        if starts and durations:
+            offset += float(starts[-1]) + float(durations[-1])
+        elif durations:
+            offset += float(sum(durations))
+        elif starts:
+            offset += float(starts[-1])
+
+    if frame_times:
+        merged['FrameTimesStart'] = frame_times
+    if frame_durations:
+        merged['FrameDuration'] = frame_durations
+        merged['AcquisitionDuration'] = float(sum(frame_durations))
+
+    return merged
+
+
+def combine_pet_runs(bids_dir: Path, layout: BIDSLayout, work_dir: Path, subjects, bids_filters):
+    import nibabel as nb
+
+    combined_root = Path(work_dir) / 'combined_bids'
+    if combined_root.exists():
+        rmtree(combined_root)
+    combined_root.mkdir(exist_ok=True, parents=True)
+
+    copytree(bids_dir, combined_root, symlinks=True, dirs_exist_ok=True, ignore=_ignore_run_pet_files)
+
+    pet_filters = (bids_filters or {}).get('pet', {})
+    pet_filters = {key: value for key, value in pet_filters.items() if key != 'run'}
+
+    combined_files = []
+    for subject in subjects:
+        pet_files = layout.get(
+            subject=subject,
+            suffix='pet',
+            extension=['.nii', '.nii.gz'],
+            return_type='filename',
+            **pet_filters,
+        )
+
+        if not pet_files:
+            continue
+
+        grouped: defaultdict[tuple, list[str]] = defaultdict(list)
+        for pet_file in pet_files:
+            entities = layout.parse_file_entities(pet_file)
+            entities.pop('run', None)
+            entities.pop('suffix', None)
+            entities.pop('extension', None)
+            entities.pop('datatype', None)
+            entities.pop('space', None)
+            key = tuple(sorted(entities.items()))
+            grouped[key].append(pet_file)
+
+        for files in grouped.values():
+            files = sorted(
+                files,
+                key=lambda path: layout.parse_file_entities(path).get('run')
+                or layout.parse_file_entities(path).get('acq')
+                or path,
+            )
+            imgs = [nb.load(file) for file in files]
+            metas = [layout.get_metadata(file) for file in files]
+            combined_img = nb.concat_images(imgs)
+
+            original = Path(files[0])
+            rel_path = original.relative_to(bids_dir)
+            new_name = re.sub(r'_run-[^_]+', '', rel_path.name)
+            output_img = combined_root / rel_path.with_name(new_name)
+            output_img.parent.mkdir(exist_ok=True, parents=True)
+            combined_img.to_filename(output_img)
+
+            combined_meta = _merge_frame_metadata(metas)
+            meta_output = output_img.with_suffix('').with_suffix('.json')
+            meta_output.write_text(json.dumps(combined_meta, indent=4))
+            combined_files.append(str(output_img))
+
+    return combined_root, combined_files
 
 
 def validate_input_dir(exec_env, bids_dir, participant_label, need_T1w=True):


### PR DESCRIPTION
## Summary
- add a `--combine-runs` CLI option to merge PET runs before preprocessing
- build combined runless PET files and metadata in a temporary BIDS copy for downstream workflows
- document the new capability in the changelog

## Testing
- python -m compileall petprep


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946feb77acc8330b6811ce8399d1797)