### PR TITLE
Merge original PET metadata with derived timing and PSF fields

### DIFF
--- a/petprep/workflows/pet/outputs.py
+++ b/petprep/workflows/pet/outputs.py
@@ -86,6 +86,13 @@ def build_psf_dict(fwhm_x=None, fwhm_y=None, fwhm_z=None):
     }
 
 
+def merge_metadata(base: dict | None, extra: dict | None = None) -> dict:
+    """Combine metadata dictionaries, preferring values from ``extra``."""
+    merged = dict(base or {})
+    merged.update(extra or {})
+    return merged
+
+
 def init_func_fit_reports_wf(
     *,
     freesurfer: bool,
@@ -652,6 +659,7 @@ def init_ds_pet_native_wf(
 ) -> pe.Workflow:
     metadata = all_metadata[0]
     timing_parameters = prepare_timing_parameters(metadata)
+    combined_metadata = merge_metadata(metadata, timing_parameters)
 
     workflow = pe.Workflow(name=name)
     inputnode = pe.Node(
@@ -694,6 +702,7 @@ def init_ds_pet_native_wf(
             name='ds_pet',
             mem_gb=DEFAULT_MEMORY_MIN_GB,
         )
+        ds_pet.inputs.meta_dict = combined_metadata
         workflow.connect([
             (inputnode, ds_pet, [
                 ('source_files', 'source_file'),
@@ -709,11 +718,12 @@ def init_ds_volumes_wf(
     *,
     bids_root: str,
     output_dir: str,
-    metadata: list[dict],
+    metadata: dict,
     pvc_method: str | None = None,
     name='ds_volumes_wf',
 ) -> pe.Workflow:
     timing_parameters = prepare_timing_parameters(metadata)
+    combined_metadata = merge_metadata(metadata, timing_parameters)
 
     workflow = pe.Workflow(name=name)
     inputnode = pe.Node(
@@ -765,6 +775,17 @@ def init_ds_volumes_wf(
         run_without_submitting=True,
         mem_gb=DEFAULT_MEMORY_MIN_GB,
     )
+    merged_metadata = pe.Node(
+        niu.Function(
+            input_names=['base', 'extra'],
+            output_names=['meta_dict'],
+            function=merge_metadata,
+        ),
+        name='merged_metadata',
+        run_without_submitting=True,
+        mem_gb=DEFAULT_MEMORY_MIN_GB,
+    )
+    merged_metadata.inputs.base = combined_metadata
 
     # PET is pre-resampled
     ds_pet = pe.Node(
@@ -803,7 +824,8 @@ def init_ds_volumes_wf(
             ('resolution', 'resolution'),
         ]),
         (sources, ds_pet, [('out', 'Sources')]),
-        (psf_meta, ds_pet, [('meta_dict', 'meta_dict')]),
+        (psf_meta, merged_metadata, [('meta_dict', 'extra')]),
+        (merged_metadata, ds_pet, [('meta_dict', 'meta_dict')]),
     ])  # fmt:skip
 
     resample_ref = pe.Node(


### PR DESCRIPTION
### Motivation
- Ensure derivative PET sidecars include original acquisition metadata so downstream analyses do not need raw files.
- Preserve and augment existing derivative metadata instead of replacing it when adding computed timing parameters.
- Attach PSF parameters computed during PVC to the derivative metadata while keeping original fields.
- Make preprocessed PET derivative metadata self-contained by combining raw and derived fields.

### Description
- Added `merge_metadata` helper to combine a base metadata dict with an extra dict, preferring values from the extra dict when keys overlap.
- In `init_ds_pet_native_wf`, merged original metadata with `timing_parameters` and set `ds_pet.inputs.meta_dict` to the combined metadata before writing derivatives.
- In `init_ds_volumes_wf`, changed the `metadata` parameter to a `dict`, merged it with timing parameters to form `combined_metadata`, and replaced the direct `psf_meta -> ds_pet` connection with `psf_meta -> merged_metadata -> ds_pet` so PSF fields are merged into the combined metadata.
- All changes are implemented in `petprep/workflows/pet/outputs.py` and reuse `merge_metadata` for both native and resampled PET datasinks.

### Testing
- No automated tests were executed for this change.
- Existing unit tests under `petprep/workflows/pet/tests/` were not run as part of this rollout.
- Changes are limited to metadata handling in `outputs.py` and do not modify datasink filenames or datatypes covered by existing tests.
- Manual code inspection and wiring checks were performed to ensure the metadata nodes are connected as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fcd72a8fc8330925f9394215a286f)