### PR TITLE
Handle mismatched PET frame start times

### DIFF
--- a/petprep/workflows/pet/hmc.py
+++ b/petprep/workflows/pet/hmc.py
@@ -78,7 +78,14 @@ def get_start_frame(
     if frame_starts is None:
         midpoints = np.cumsum(durations) - durations / 2.0
     else:
-        midpoints = np.asarray(frame_starts, dtype=float) + durations / 2.0
+        frame_starts = np.asarray(frame_starts, dtype=float)
+        if frame_starts.size == durations.size + 1:
+            frame_starts = frame_starts[:-1]
+        if frame_starts.size != durations.size:
+            size = min(frame_starts.size, durations.size)
+            frame_starts = frame_starts[:size]
+            durations = durations[:size]
+        midpoints = frame_starts + durations / 2.0
 
     idxs = np.where(midpoints > start_time)[0]
     return int(idxs[0]) if idxs.size > 0 else int(len(midpoints) - 1)

--- a/petprep/workflows/pet/tests/test_hmc.py
+++ b/petprep/workflows/pet/tests/test_hmc.py
@@ -24,6 +24,12 @@ def test_get_start_frame_with_starts():
     assert get_start_frame(durations, 15, frame_starts) == 1
 
 
+def test_get_start_frame_with_extra_start():
+    durations = [3600, 300, 300, 300, 300, 300, 300]
+    frame_starts = [0, 3600, 3900, 4200, 4500, 4800, 5100, 5400]
+    assert get_start_frame(durations, 0, frame_starts) == 0
+
+
 def test_get_start_frame_empty():
     assert get_start_frame([], 50) == 0
     assert get_start_frame(None, 50) == 0


### PR DESCRIPTION
### Motivation
- Prevent broadcast errors when `frame_starts` metadata (e.g., from listmode-derived JSON) has a different length than `frame_durations` by making `get_start_frame` resilient to extra or fewer entries.

### Description
- Trim or align `frame_starts` and `durations` in `get_start_frame` so that an extra final boundary (`len(frame_starts) == len(durations) + 1`) or other size mismatches do not cause shape/broadcast errors, and compute midpoints from the clipped arrays.
- Add a regression test `test_get_start_frame_with_extra_start` in `petprep/workflows/pet/tests/test_hmc.py` that covers an extra frame-start entry case.

### Testing
- No automated test suite was executed in this rollout, but a unit test (`test_get_start_frame_with_extra_start`) was added to cover the reported scenario.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a4799ba2c8330a8f3f739bd902dbb)