### PR TITLE
Refine motion reportlet cropping mask

### DIFF
--- a/petprep/interfaces/motion.py
+++ b/petprep/interfaces/motion.py
@@ -14,6 +14,7 @@ import numpy as np
 import pandas as pd
 from imageio import v2 as imageio
 from nilearn import image
+from nilearn.masking import compute_epi_mask
 from nilearn.plotting import plot_epi
 from nilearn.plotting.find_cuts import find_xyz_cut_coords
 from nipype.interfaces.base import (
@@ -24,6 +25,7 @@ from nipype.interfaces.base import (
     isdefined,
     traits,
 )
+from scipy import ndimage
 
 
 class MotionPlotInputSpec(BaseInterfaceInputSpec):
@@ -67,10 +69,12 @@ class MotionPlot(SimpleInterface):
         svg_file = runtime.cwd / 'pet_motion_hmc.svg'
         svg_file.parent.mkdir(parents=True, exist_ok=True)
 
-        mid_orig, cut_coords_orig, vmin_orig, vmax_orig = self._compute_display_params(
-            self.inputs.original_pet
+        mid_orig, cut_coords_orig, vmin_orig, vmax_orig, crop_slices = (
+            self._compute_display_params(self.inputs.original_pet)
         )
-        _, _, vmin_corr, vmax_corr = self._compute_display_params(self.inputs.corrected_pet)
+        _, _, vmin_corr, vmax_corr, _ = self._compute_display_params(
+            self.inputs.corrected_pet, crop_slices=crop_slices
+        )
 
         fd_values = None
         if isdefined(self.inputs.fd_file):
@@ -84,6 +88,7 @@ class MotionPlot(SimpleInterface):
             vmax_orig=vmax_orig,
             vmin_corr=vmin_corr,
             vmax_corr=vmax_corr,
+            crop_slices=crop_slices,
             fd_values=fd_values,
         )
 
@@ -91,19 +96,75 @@ class MotionPlot(SimpleInterface):
 
         return runtime
 
-    def _compute_display_params(self, in_file: str):
+    def _compute_display_params(
+        self,
+        in_file: str,
+        crop_slices: tuple[slice, slice, slice] | None = None,
+    ):
         img = nib.load(in_file)
         if img.ndim == 3:
             mid_img = img
         else:
             mid_img = image.index_img(in_file, img.shape[-1] // 2)
 
-        data = mid_img.get_fdata().astype(float)
+        if crop_slices is None:
+            crop_slices = self._compute_crop_slices(mid_img)
+
+        cropped_mid = self._crop_img(mid_img, crop_slices)
+        data = cropped_mid.get_fdata().astype(float)
         vmax = float(np.percentile(data.flatten(), 99.9))
         vmin = float(np.percentile(data.flatten(), 80))
-        cut_coords = find_xyz_cut_coords(mid_img)
+        cut_coords = find_xyz_cut_coords(cropped_mid)
 
-        return mid_img, cut_coords, vmin, vmax
+        return cropped_mid, cut_coords, vmin, vmax, crop_slices
+
+    def _compute_crop_slices(
+        self, img: nib.spatialimages.SpatialImage
+    ) -> tuple[slice, slice, slice] | None:
+        try:
+            mask_img = compute_epi_mask(img)
+            mask_data = np.asanyarray(mask_img.dataobj) > 0
+        except Exception:
+            data = np.asanyarray(img.dataobj)
+            positive = data[data > 0]
+            if positive.size == 0:
+                return None
+            threshold = float(np.percentile(positive, 80))
+            mask_data = data > threshold
+
+        mask_data = self._largest_connected_component(mask_data)
+
+        if not mask_data.any():
+            return None
+
+        coords = np.array(np.where(mask_data))
+        start = coords.min(axis=1)
+        end = coords.max(axis=1) + 1
+        return tuple(slice(int(s), int(e)) for s, e in zip(start, end))
+
+    def _largest_connected_component(self, mask_data: np.ndarray) -> np.ndarray:
+        labeled, num = ndimage.label(mask_data)
+        if num <= 1:
+            return mask_data
+        counts = np.bincount(labeled.ravel())
+        counts[0] = 0
+        largest = counts.argmax()
+        return labeled == largest
+
+    def _crop_img(
+        self,
+        img: nib.spatialimages.SpatialImage,
+        crop_slices: tuple[slice, slice, slice] | None,
+    ) -> nib.spatialimages.SpatialImage:
+        if crop_slices is None:
+            return img
+
+        data = np.asanyarray(img.dataobj)[crop_slices]
+        affine = img.affine.copy()
+        zooms = img.header.get_zooms()[:3]
+        starts = np.array([slc.start or 0 for slc in crop_slices])
+        affine[:3, 3] += starts * zooms
+        return img.__class__(data, affine, img.header)
 
     def _load_framewise_displacement(self, fd_file: str) -> np.ndarray:
         framewise_disp = pd.read_csv(fd_file, sep='\t')
@@ -130,6 +191,7 @@ class MotionPlot(SimpleInterface):
         vmax_orig: float,
         vmin_corr: float,
         vmax_corr: float,
+        crop_slices: tuple[slice, slice, slice] | None,
         fd_values: np.ndarray | None,
     ) -> Path:
         orig_img = nib.load(self.inputs.original_pet)
@@ -150,8 +212,14 @@ class MotionPlot(SimpleInterface):
                 orig_png = Path(tmpdir) / f'orig_{idx:04d}.png'
                 corr_png = Path(tmpdir) / f'corr_{idx:04d}.png'
 
+                orig_frame = self._crop_img(
+                    image.index_img(self.inputs.original_pet, idx), crop_slices
+                )
+                corr_frame = self._crop_img(
+                    image.index_img(self.inputs.corrected_pet, idx), crop_slices
+                )
                 plot_epi(
-                    image.index_img(self.inputs.original_pet, idx),
+                    orig_frame,
                     colorbar=True,
                     display_mode='ortho',
                     title=f'Before motion correction | Frame {idx + 1}',
@@ -161,7 +229,7 @@ class MotionPlot(SimpleInterface):
                     output_file=str(orig_png),
                 )
                 plot_epi(
-                    image.index_img(self.inputs.corrected_pet, idx),
+                    corr_frame,
                     colorbar=True,
                     display_mode='ortho',
                     title=f'After motion correction | Frame {idx + 1}',


### PR DESCRIPTION
### Motivation
- PET series can include out-of-body counts that break automatic brain masking and yield poor field-of-view for motion reportlets, so masking needs to be more robust to wide FOV noise.
- Ensure before/after frames share a consistent, brain-focused framing so cut coordinates and color scaling remain meaningful across frames.

### Description
- Use `compute_epi_mask` to derive a mask in `_compute_crop_slices` with a percentile-based fallback threshold (80th percentile of positive voxels) when automatic masking fails. 
- Keep only the largest connected component of the mask via a new `_largest_connected_component` helper using `ndimage.label` to ignore spurious out-of-body islands. 
- Add `_crop_img` to crop image data and adjust the image affine using header `zooms` so spatial metadata remain correct after cropping. 
- Thread `crop_slices` through `_compute_display_params`, `_run_interface`, and `_build_animation` and apply the crop to each per-frame image prior to calling `plot_epi` so before/after views share framing and color scaling is computed from the cropped midpoint. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dfec31d848330b2f447943ad950a0)