### PR TITLE
Add --pet-lr-flip option and implement PET left-right flipping in fit workflow

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -41,6 +41,20 @@ downstream consequences in `#939 <https://github.com/nipreps/petprep/issues/939>
 So for OpenFMRI, we've been excluding these subjects, and for user-supplied data, we would recommend
 reverting to the original, defaced, T1w images to ensure more uniform preprocessing.
 
+How should I safeguard against left-right (LR) flips in PET data?
+-----------------------------------------------------------------
+PETPrep assumes the NIfTI header affines are correct and does not automatically correct
+left-right flips introduced during conversion (for example, when going from Analyze to NIfTI).
+If a PET series is LR-flipped, registration to the (RAS-conformed) T1w reference will typically
+appear mirrored in reportlets.
+
+To safeguard against this, validate and, if needed, fix PET orientation before running PETPrep.
+After running, review the reportlets and the reported "Original orientation" for each PET series
+to ensure the orientation matches expectations for your site and scanner. If a mismatch is
+detected, fix the PET NIfTI header (or re-convert from the original data) and rerun PETPrep so
+all downstream outputs are consistent. For datasets that require a manual correction, you can
+also provide the ``--pet-lr-flip`` flag to flip the PET data before preprocessing.
+
 
 My *PETPrep* run is hanging...
 -------------------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -251,6 +251,13 @@ will raise an error before preprocessing starts.
   PET-to-T1w registrations for each, and keeps whichever option scores best for
   anatomical alignment. 
 
+Left-right flips
+----------------
+PETPrep expects the PET NIfTI headers to have correct orientation information.
+If your PET data were converted with a left-right flip (for example, from Analyze
+to NIfTI), use :option:`--pet-lr-flip` to flip the data before preprocessing so
+that downstream registration and outputs are consistent.
+
 Anatomical reference selection
 ------------------------------
 PETPrep uses an anatomical reference when registering PET data to the structural

--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -409,6 +409,13 @@ https://petprep.readthedocs.io/en/{currentv.base_version if is_release else 'lat
         ),
     )
     g_conf.add_argument(
+        '--pet-lr-flip',
+        action='store_true',
+        default=False,
+        help='Flip PET data left-right before preprocessing. Use this option to correct '
+        'datasets that were converted with a left-right flip.',
+    )
+    g_conf.add_argument(
         '--force-bbr',
         action=DeprecatedAction,
         help='Deprecated - use `--force bbr` instead.',

--- a/petprep/config.py
+++ b/petprep/config.py
@@ -622,6 +622,8 @@ class workflow(_Config):
     """Whether to fix the reference frame during head-motion estimation."""
     hmc_off: bool = False
     """Disable head-motion correction and keep data uncorrected."""
+    pet_lr_flip: bool = False
+    """Flip PET data left-right before processing."""
     seg = 'gtm'
     """Segmentation approach ('gtm', 'brainstem', 'thalamicNuclei',
     'hippocampusAmygdala', 'wm', 'raphe', 'limbic')."""

--- a/petprep/workflows/pet/fit.py
+++ b/petprep/workflows/pet/fit.py
@@ -223,6 +223,37 @@ def _extract_sum_image(pet_file: str, output_dir: 'Path') -> str:
     return str(out_file)
 
 
+def _flip_lr_image(pet_file: str, output_dir: 'Path') -> str:
+    """Flip a PET NIfTI left-right in voxel space."""
+
+    from pathlib import Path
+
+    import nibabel as nb
+    import numpy as np
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    img = nb.load(pet_file)
+    data = np.asanyarray(img.dataobj)
+    flipped = np.flip(data, axis=0)
+
+    affine = img.affine.copy()
+    affine[:3, 0] *= -1
+    affine[:3, 3] += img.affine[:3, 0] * (img.shape[0] - 1)
+
+    hdr = img.header.copy()
+
+    pet_path = Path(pet_file)
+    pet_stem = pet_path
+    while pet_stem.suffix:
+        pet_stem = pet_stem.with_suffix('')
+    out_file = output_dir / f'{pet_stem.name}_lrflip.nii.gz'
+
+    img.__class__(flipped, affine, hdr).to_filename(out_file)
+    return str(out_file)
+
+
 def _select_best_petref(labels, scores, transforms, inv_transforms, winners, petrefs):
     """Select the PET reference with the lowest registration cost."""
 
@@ -440,12 +471,14 @@ def init_pet_fit_wf(
     if precomputed is None:
         precomputed = {}
     pet_series = listify(pet_series)
+    source_pet_series = pet_series
     layout = config.execution.layout
 
-    pet_file = pet_series[0]
+    source_pet_file = source_pet_series[0]
+    pet_file = source_pet_file
 
     # Get metadata from PET file(s)
-    metadata = layout.get_metadata(pet_file)
+    metadata = layout.get_metadata(source_pet_file)
     orientation = ''.join(nb.aff2axcodes(nb.load(pet_file).affine))
 
     pet_tlen, mem_gb = estimate_pet_mem_usage(pet_file)
@@ -460,6 +493,12 @@ def init_pet_fit_wf(
         transforms.get('petref2anat'), 'PET-to-T1w transform'
     )
 
+    if config.workflow.pet_lr_flip and (petref or hmc_xforms or petref2anat_xform):
+        raise ValueError(
+            'The --pet-lr-flip option cannot be combined with precomputed PET derivatives. '
+            'Disable --pet-lr-flip or remove the precomputed petref/transforms.'
+        )
+
     if (petref is None) ^ (hmc_xforms is None):
         raise ValueError("Both 'petref' and 'hmc' transforms must be provided together.")
 
@@ -470,12 +509,24 @@ def init_pet_fit_wf(
         petref = None
         hmc_xforms = None
 
+    if config.workflow.pet_lr_flip:
+        config.loggers.workflow.warning(
+            'Applying requested left-right flip to PET data before preprocessing.'
+        )
+        config.execution.work_dir.mkdir(parents=True, exist_ok=True)
+        pet_series = [
+            _flip_lr_image(pet_file, config.execution.work_dir) for pet_file in source_pet_series
+        ]
+        pet_file = pet_series[0]
+        orientation = ''.join(nb.aff2axcodes(nb.load(pet_file).affine))
+
     workflow = Workflow(name=name)
 
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=[
                 'pet_file',
+                'source_file',
                 # Anatomical coregistration
                 't1w_preproc',
                 't1w_mask',
@@ -491,6 +542,7 @@ def init_pet_fit_wf(
         name='inputnode',
     )
     inputnode.inputs.pet_file = pet_series
+    inputnode.inputs.source_file = source_pet_file
 
     outputnode = pe.Node(
         niu.IdentityInterface(
@@ -731,7 +783,7 @@ def init_pet_fit_wf(
             ('hmc_xforms', 'motion_xfm'),
         ]),
         (inputnode, func_fit_reports_wf, [
-            ('pet_file', 'inputnode.source_file'),
+            ('source_file', 'inputnode.source_file'),
             ('t1w_preproc', 'inputnode.t1w_preproc'),
             # May not need all of these
             ('t1w_mask', 'inputnode.t1w_mask'),
@@ -768,7 +820,7 @@ def init_pet_fit_wf(
             bids_root=layout.root,
             output_dir=config.execution.petprep_dir,
         )
-        ds_hmc_wf.inputs.inputnode.source_files = [pet_file]
+        ds_hmc_wf.inputs.inputnode.source_files = [source_pet_file]
 
         ds_petref_wf = init_ds_petref_wf(
             bids_root=layout.root,
@@ -776,7 +828,7 @@ def init_pet_fit_wf(
             desc='hmc',
             name='ds_petref_wf',
         )
-        ds_petref_wf.inputs.inputnode.source_files = [pet_file]
+        ds_petref_wf.inputs.inputnode.source_files = [source_pet_file]
 
         # Validation node for the original PET file
         val_pet = pe.Node(ValidateImage(), name='val_pet')
@@ -962,7 +1014,7 @@ def init_pet_fit_wf(
         desc='brain',
         name='ds_petmask_wf',
     )
-    ds_petmask_wf.inputs.inputnode.source_files = [pet_file]
+    ds_petmask_wf.inputs.inputnode.source_files = [source_pet_file]
     workflow.connect([(merge_mask, ds_petmask_wf, [('out', 'inputnode.petmask')])])
 
     # Stage 3: Coregistration
@@ -1133,7 +1185,7 @@ def init_pet_fit_wf(
 
         pet_ref_tacs_wf = init_pet_ref_tacs_wf(name='pet_ref_tacs_wf')
         pet_ref_tacs_wf.inputs.inputnode.metadata = str(
-            Path(pet_file).with_suffix('').with_suffix('.json')
+            Path(source_pet_file).with_suffix('').with_suffix('.json')
         )
         pet_ref_tacs_wf.inputs.inputnode.ref_mask_name = config.workflow.ref_mask_name
 
@@ -1152,7 +1204,7 @@ def init_pet_fit_wf(
                 run_without_submitting=True,
                 mem_gb=config.DEFAULT_MEMORY_MIN_GB,
             )
-            ds_ref_tacs.inputs.source_file = pet_file
+            ds_ref_tacs.inputs.source_file = source_pet_file
 
         workflow.connect([(inputnode, gm_select, [('t1w_tpms', 'inlist')])])
 

--- a/petprep/workflows/pet/tests/test_fit.py
+++ b/petprep/workflows/pet/tests/test_fit.py
@@ -17,6 +17,7 @@ from ..fit import (
     _construct_nu_path,
     _detect_large_pet_mask,
     _extract_first5min_image,
+    _flip_lr_image,
     _extract_sum_image,
     _extract_twa_image,
     _select_anatomical_reference,
@@ -649,6 +650,20 @@ def test_extract_sum_image(tmp_path: Path):
     pet_3d = tmp_path / 'pet3d.nii.gz'
     nb.Nifti1Image(np.zeros((2, 2, 2), dtype=np.float32), np.eye(4)).to_filename(pet_3d)
     assert _extract_sum_image(str(pet_3d), tmp_path / 'out') == str(pet_3d)
+
+
+def test_flip_lr_image(tmp_path: Path):
+    data = np.arange(8, dtype=np.float32).reshape((2, 2, 2))
+    pet_img = nb.Nifti1Image(data, np.eye(4))
+    pet_file = tmp_path / 'pet.nii.gz'
+    pet_img.to_filename(pet_file)
+
+    out_file = _flip_lr_image(str(pet_file), tmp_path / 'out')
+
+    flipped = nb.load(out_file)
+    assert np.allclose(flipped.get_fdata(), np.flip(data, axis=0))
+    assert np.allclose(flipped.affine[0, 0], -1.0)
+    assert np.allclose(flipped.affine[0, 3], 1.0)
 
 
 def test_extract_first5min_image(tmp_path: Path):


### PR DESCRIPTION
### Motivation
- Provide a way to correct datasets whose PET NIfTIs were converted with a left-right flip so downstream registration is not mirrored.
- Allow an explicit CLI-driven correction prior to preprocessing when automatic header correction is not desirable or possible.

### Description
- Add a workflow config flag `pet_lr_flip` and a CLI option `--pet-lr-flip` wired into `petprep.config` and `petprep/cli/parser.py` to request a left-right flip before processing.
- Implemented `_flip_lr_image` in `petprep/workflows/pet/fit.py` to flip PET data in voxel space and adjust the affine accordingly, and integrated it into `init_pet_fit_wf` so flipped images are used for processing while preserving the original source file provenance via a `source_file` field.
- Added a safeguard that raises a `ValueError` if `--pet-lr-flip` is used together with precomputed PET derivatives (`petref`, `hmc`, or `petref2anat`) to avoid inconsistent inputs.
- Documented the new option in `docs/usage.rst` and `docs/faq.rst` and updated report/datasink wiring to continue reporting original source files where appropriate.

### Testing
- Added a unit test `test_flip_lr_image` in `petprep/workflows/pet/tests/test_fit.py` that verifies voxel data are flipped and the affine is updated as expected, but no tests were executed locally as part of this change (CI will run the test suite).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e146368e883308dbfb15f72041058)