### PR TITLE
Include fsaverage in default output spaces and derivative collection

### DIFF
--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -894,6 +894,7 @@ def parse_args(args=None, namespace=None):
             [
                 Reference('MNI152NLin2009cAsym', {'res': 'native'}),
                 Reference('T1w'),
+                Reference('fsaverage'),
             ],
         )
 

--- a/petprep/workflows/base.py
+++ b/petprep/workflows/base.py
@@ -242,7 +242,7 @@ It is released under the [CC0]\
         from smriprep.utils.bids import collect_derivatives as collect_anat_derivatives
 
         std_spaces = spaces.get_spaces(nonstandard=False, dim=(3,))
-        std_spaces.append('fsnative')
+        std_spaces.extend(['fsnative', 'fsaverage'])
         for deriv_dir in config.execution.derivatives.values():
             anatomical_cache.update(
                 collect_anat_derivatives(


### PR DESCRIPTION
### Motivation

- Ensure surface-based outputs include the `fsaverage` reference by default so downstream workflows and derivative collection can operate on the common FreeSurfer surface space.

### Description

- Initialize `config.execution.output_spaces` in `petprep/cli/parser.py` to include `Reference('fsaverage')` alongside the existing defaults.
- Add `fsaverage` to the set of standard spaces used when collecting anatomical derivatives in `petprep/workflows/base.py` by extending `std_spaces` with `['fsnative', 'fsaverage']`.

### Testing

- Ran the project's automated test suite (`pytest`) and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c24087e7c4833087f2a13b6a6e68dd)