### PR TITLE
MAINT: fix pytest scipy dependency issue

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ pass_env =
   PYTHON_GIL
 deps =
   py313: traits @ git+https://github.com/enthought/traits.git@10954eb
+  pre: scipy<1.16
 extras = test
 setenv =
   pre: PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple


### PR DESCRIPTION
Added a dependency constraint in tox so some environments install scipy<1.16, preventing the SciPy/scikit-learn ABI mismatch observed in some recent PRs when running GA. 