### PR TITLE
Add group-level analysis mode for morphometry summaries

### DIFF
--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -171,9 +171,9 @@ def _build_parser(**kwargs):
     )
     parser.add_argument(
         'analysis_level',
-        choices=['participant'],
-        help='Processing stage to be run, only "participant" in the case of '
-        'PETPrep (see BIDS-Apps specification).',
+        choices=['participant', 'group'],
+        help='Processing stage to be run. "participant" runs subject-level preprocessing, '
+        'and "group" summarizes participant-level derivatives.',
     )
 
     g_bids = parser.add_argument_group('Options for filtering BIDS queries')

--- a/petprep/cli/run.py
+++ b/petprep/cli/run.py
@@ -39,6 +39,24 @@ def main():
 
     parse_args()
 
+    if config.execution.analysis_level == 'group':
+        from petprep.reports.core import generate_group_morph_report
+
+        try:
+            summary_tsv, summary_html = generate_group_morph_report(
+                config.execution.petprep_dir,
+                participant_label=config.execution.participant_label,
+            )
+        except RuntimeError as err:
+            config.loggers.cli.error(str(err))
+            sys.exit(1)
+
+        config.loggers.workflow.log(
+            25,
+            f'Generated group-level morphometry summary: {summary_tsv} and {summary_html}',
+        )
+        sys.exit(0)
+
     # Code Carbon
     if config.execution.track_carbon:
         from codecarbon import OfflineEmissionsTracker

--- a/petprep/cli/tests/test_parser.py
+++ b/petprep/cli/tests/test_parser.py
@@ -71,6 +71,15 @@ def test_parser_valid(tmp_path, args):
     assert opts.bids_dir == datapath
 
 
+def test_parser_accepts_group_analysis_level(tmp_path):
+    datapath = tmp_path / 'data'
+    datapath.mkdir(exist_ok=True)
+
+    opts = _build_parser().parse_args([str(datapath), 'out/', 'group'])
+
+    assert opts.analysis_level == 'group'
+
+
 @pytest.mark.parametrize(
     ('argval', 'gb'),
     [

--- a/petprep/config.py
+++ b/petprep/config.py
@@ -428,6 +428,8 @@ class execution(_Config):
     the command line) as spatial references for outputs."""
     reports_only = False
     """Only build the reports, based on the reportlets found in a cached working directory."""
+    analysis_level = 'participant'
+    """The BIDS-Apps analysis level requested on the command line."""
     run_uuid = f'{strftime("%Y%m%d-%H%M%S")}_{uuid4()}'
     """Unique identifier of this particular run."""
     participant_label = None

--- a/petprep/reports/core.py
+++ b/petprep/reports/core.py
@@ -22,6 +22,7 @@
 #
 from pathlib import Path
 
+import pandas as pd
 from nireports.assembler.report import Report
 
 from .. import config, data
@@ -178,3 +179,76 @@ def generate_reports(
                     errors.append(report_error)
 
     return errors
+
+
+def generate_group_morph_report(output_dir, participant_label=None):
+    """Generate a group-level summary report from participant morphometry files."""
+    output_dir = Path(output_dir)
+    group_dir = output_dir / 'group'
+    group_dir.mkdir(parents=True, exist_ok=True)
+
+    if participant_label:
+        participants = [label.removeprefix('sub-') for label in participant_label]
+    else:
+        participants = sorted(path.name.removeprefix('sub-') for path in output_dir.glob('sub-*'))
+
+    morph_dfs = []
+    for subject_id in participants:
+        sub_dir = output_dir / f'sub-{subject_id}'
+        if not sub_dir.exists():
+            continue
+
+        for morph_file in sub_dir.rglob('*_morph.tsv'):
+            if 'anat' not in morph_file.parts:
+                continue
+            sub_df = pd.read_csv(morph_file, sep='\t')
+            sub_df['participant_id'] = f'sub-{subject_id}'
+            sub_df['source_file'] = str(morph_file.relative_to(output_dir))
+            morph_dfs.append(sub_df)
+
+    if not morph_dfs:
+        raise RuntimeError(
+            f'No participant morphometry files (*_morph.tsv) were found under {output_dir}.'
+        )
+
+    group_df = pd.concat(morph_dfs, ignore_index=True)
+    numeric_cols = [
+        col
+        for col in group_df.select_dtypes(include='number').columns
+        if col not in {'index', 'id'}
+    ]
+    if not numeric_cols:
+        raise RuntimeError('No numeric columns were found in participant morphometry tables.')
+
+    groupby_cols = [
+        col
+        for col in group_df.columns
+        if col not in set(numeric_cols) | {'participant_id', 'source_file'}
+    ]
+
+    summary_df = (
+        group_df.groupby(groupby_cols, dropna=False)[numeric_cols]
+        .agg(['count', 'mean', 'std', 'min', 'max'])
+        .reset_index()
+    )
+    summary_df.columns = [
+        '_'.join(filter(None, map(str, col))).rstrip('_') for col in summary_df.columns.to_flat_index()
+    ]
+
+    summary_tsv = group_dir / 'desc-morph_group.tsv'
+    summary_html = group_dir / 'report.html'
+
+    summary_df.to_csv(summary_tsv, sep='\t', index=False)
+    summary_html.write_text(
+        '\n'.join(
+            [
+                '<html><head><meta charset="utf-8"><title>PETPrep Group Morphometry Report</title></head><body>',
+                '<h1>PETPrep group morphometry summary</h1>',
+                '<p>Summary statistics across participant-level <code>*_morph.tsv</code> outputs.</p>',
+                summary_df.to_html(index=False, border=0),
+                '</body></html>',
+            ]
+        )
+    )
+
+    return summary_tsv, summary_html

--- a/petprep/reports/tests/test_reports.py
+++ b/petprep/reports/tests/test_reports.py
@@ -1,6 +1,7 @@
 import shutil
 from pathlib import Path
 
+import pandas as pd
 import pytest
 from bids.layout import BIDSLayout
 
@@ -177,3 +178,26 @@ def test_reportlets_dir_scoped_to_subject(tmp_path, monkeypatch):
     generate_reports(['02'], tmp_path, 'fake', work_dir=work_dir)
 
     assert recorded_reportlets == [target]
+
+
+def test_generate_group_morph_report(tmp_path):
+    anat_dir_1 = tmp_path / 'sub-01' / 'anat'
+    anat_dir_1.mkdir(parents=True)
+    anat_dir_2 = tmp_path / 'sub-02' / 'anat'
+    anat_dir_2.mkdir(parents=True)
+
+    (anat_dir_1 / 'sub-01_desc-test_morph.tsv').write_text(
+        'index\tname\tvolume-mm3\n1\tregionA\t100.0\n2\tregionB\t200.0\n'
+    )
+    (anat_dir_2 / 'sub-02_desc-test_morph.tsv').write_text(
+        'index\tname\tvolume-mm3\n1\tregionA\t120.0\n2\tregionB\t220.0\n'
+    )
+
+    summary_tsv, summary_html = core.generate_group_morph_report(tmp_path)
+
+    assert summary_tsv.is_file()
+    assert summary_html.is_file()
+
+    summary_df = pd.read_csv(summary_tsv, sep='\t')
+    assert set(summary_df['name']) == {'regionA', 'regionB'}
+    assert 'volume-mm3_mean' in summary_df.columns


### PR DESCRIPTION
### Motivation
- Provide a BIDS-Apps style `group` analysis level so users can produce dataset-level summaries after running the `participant` workflows, similar to MRIQC.
- Summarize volumetric outputs stored in participant `*_morph.tsv` files (under `anat/`) into a single group report for convenient downstream inspection.

### Description
- Add `group` as a valid `analysis_level` to the CLI (`_build_parser`) so the app can be invoked with `group` in addition to `participant`.
- Introduce `execution.analysis_level` in the configuration and branch `main()` in `petprep/cli/run.py` to short-circuit normal workflow execution when `analysis_level == 'group'` and run the group report generator instead.
- Implement `generate_group_morph_report(output_dir, participant_label=None)` in `petprep/reports/core.py` which collects participant `*_morph.tsv` files under each `sub-*/anat/`, concatenates them with `pandas`, computes per-region summary statistics (`count`, `mean`, `std`, `min`, `max`) across numeric columns, and writes `group/desc-morph_group.tsv` and `group/report.html`.
- Add tests: `test_parser_accepts_group_analysis_level` to validate CLI parsing of `group`, and `test_generate_group_morph_report` to validate collection, aggregation, and output columns.

### Testing
- Attempted `pytest` invocation with default project addopts failed due to CI-local `pytest` addopts interfering with unsupported coverage plugin options (error raised by pytest about `--cov` flags), so a constrained run was used to avoid addopts injection.
- Ran `pytest -q -o addopts='' petprep/reports/tests/test_reports.py::test_generate_group_morph_report petprep/cli/tests/test_parser.py::test_parser_accepts_group_analysis_level` and both tests passed.
- The implemented behavior was exercised by the new unit tests which validated CLI parsing and the group morphometry aggregation outputs (`desc-morph_group.tsv` and `report.html`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcdf5118248330b7b9efed18fb03a0)