### PR TITLE
Add group-level summary for *_timeseries.tsv confounds

### DIFF
--- a/petprep/reports/core.py
+++ b/petprep/reports/core.py
@@ -182,7 +182,7 @@ def generate_reports(
 
 
 def generate_group_morph_report(output_dir, participant_label=None):
-    """Generate a group-level summary report from participant morphometry files."""
+    """Generate group-level summaries from participant morphometry and timeseries files."""
     output_dir = Path(output_dir)
     group_dir = output_dir / 'group'
     group_dir.mkdir(parents=True, exist_ok=True)
@@ -207,9 +207,7 @@ def generate_group_morph_report(output_dir, participant_label=None):
             morph_dfs.append(sub_df)
 
     if not morph_dfs:
-        raise RuntimeError(
-            f'No participant morphometry files (*_morph.tsv) were found under {output_dir}.'
-        )
+        raise RuntimeError(f'No participant files (*_morph.tsv) were found under {output_dir}.')
 
     group_df = pd.concat(morph_dfs, ignore_index=True)
     numeric_cols = [
@@ -236,9 +234,33 @@ def generate_group_morph_report(output_dir, participant_label=None):
     ]
 
     summary_tsv = group_dir / 'desc-morph_group.tsv'
+    confounds_tsv = group_dir / 'desc-timeseries_group.tsv'
     summary_html = group_dir / 'report.html'
 
     summary_df.to_csv(summary_tsv, sep='\t', index=False)
+
+    timeseries_dfs = []
+    for subject_id in participants:
+        sub_dir = output_dir / f'sub-{subject_id}'
+        if not sub_dir.exists():
+            continue
+
+        for timeseries_file in sub_dir.rglob('*_timeseries.tsv'):
+            sub_df = pd.read_csv(timeseries_file, sep='\t')
+            numeric_cols = list(sub_df.select_dtypes(include='number').columns)
+            if not numeric_cols:
+                continue
+            timeseries_dfs.append(sub_df[numeric_cols])
+
+    confounds_summary_df = pd.DataFrame()
+    if timeseries_dfs:
+        confounds_df = pd.concat(timeseries_dfs, ignore_index=True)
+        confounds_summary_df = (
+            confounds_df.agg(['count', 'mean', 'std', 'min', 'max']).transpose().reset_index()
+        )
+        confounds_summary_df = confounds_summary_df.rename(columns={'index': 'name'})
+        confounds_summary_df.to_csv(confounds_tsv, sep='\t', index=False)
+
     summary_html.write_text(
         '\n'.join(
             [
@@ -246,6 +268,16 @@ def generate_group_morph_report(output_dir, participant_label=None):
                 '<h1>PETPrep group morphometry summary</h1>',
                 '<p>Summary statistics across participant-level <code>*_morph.tsv</code> outputs.</p>',
                 summary_df.to_html(index=False, border=0),
+                '<h2>PETPrep group timeseries summary</h2>',
+                (
+                    '<p>Summary statistics across numeric columns from participant-level '
+                    '<code>*_timeseries.tsv</code> outputs.</p>'
+                ),
+                (
+                    confounds_summary_df.to_html(index=False, border=0)
+                    if not confounds_summary_df.empty
+                    else '<p>No numeric <code>*_timeseries.tsv</code> files were found.</p>'
+                ),
                 '</body></html>',
             ]
         )

--- a/petprep/reports/tests/test_reports.py
+++ b/petprep/reports/tests/test_reports.py
@@ -192,6 +192,20 @@ def test_generate_group_morph_report(tmp_path):
     (anat_dir_2 / 'sub-02_desc-test_morph.tsv').write_text(
         'index\tname\tvolume-mm3\n1\tregionA\t120.0\n2\tregionB\t220.0\n'
     )
+    pet_dir_1 = tmp_path / 'sub-01' / 'pet'
+    pet_dir_1.mkdir(parents=True)
+    pet_dir_2 = tmp_path / 'sub-02' / 'pet'
+    pet_dir_2.mkdir(parents=True)
+    (pet_dir_1 / 'sub-01_desc-confounds_timeseries.tsv').write_text(
+        'std_dvars\tdvars\tframewise_displacement\trmsd\ttrans_x\n'
+        '1.0\t0.8\t0.20\t0.05\t0.1\n'
+        '1.2\t1.0\t0.40\t0.07\t0.2\n'
+    )
+    (pet_dir_2 / 'sub-02_desc-confounds_timeseries.tsv').write_text(
+        'std_dvars\tdvars\tframewise_displacement\trmsd\ttrans_x\n'
+        '0.9\t0.7\t0.30\t0.06\t0.0\n'
+        '1.1\t0.9\t0.50\t0.08\t0.3\n'
+    )
 
     summary_tsv, summary_html = core.generate_group_morph_report(tmp_path)
 
@@ -201,3 +215,9 @@ def test_generate_group_morph_report(tmp_path):
     summary_df = pd.read_csv(summary_tsv, sep='\t')
     assert set(summary_df['name']) == {'regionA', 'regionB'}
     assert 'volume-mm3_mean' in summary_df.columns
+
+    confounds_summary_tsv = tmp_path / 'group' / 'desc-timeseries_group.tsv'
+    assert confounds_summary_tsv.is_file()
+
+    confounds_df = pd.read_csv(confounds_summary_tsv, sep='\t')
+    assert set(confounds_df['name']) >= {'std_dvars', 'dvars', 'framewise_displacement', 'rmsd'}


### PR DESCRIPTION
### Motivation
- Provide group-level summaries for numeric confound/time-series columns (e.g., `std_dvars`, `dvars`, `framewise_displacement`, motion parameters) in the same way morphometry outputs are summarized.
- Make it easier to inspect confound distributions across subjects/sessions without manual aggregation.

### Description
- Extended `generate_group_morph_report` in `petprep/reports/core.py` to collect numeric columns from participant `*_timeseries.tsv` files and compute `count/mean/std/min/max` across all concatenated rows.
- Added a new group-level output file `group/desc-timeseries_group.tsv` and included a “PETPrep group timeseries summary” section in the generated `group/report.html`.
- Kept existing morphometry output (`group/desc-morph_group.tsv`) and the function return signature unchanged for compatibility.
- Updated `petprep/reports/tests/test_reports.py` to include synthetic `*_timeseries.tsv` inputs and assertions verifying the new group confounds summary file and expected columns.

### Testing
- Attempted `pytest -q petprep/reports/tests/test_reports.py::test_generate_group_morph_report` which initially failed in this environment due to project `addopts` requiring `pytest-cov` (not available).
- Ran the test with `pytest -q -o addopts='' petprep/reports/tests/test_reports.py::test_generate_group_morph_report`, which passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce23ee9988330a2b8bcffc8f992d9)