### PR TITLE
Fix SegmentHA_T1 to use configured FreeSurfer SUBJECTS_DIR explicitly

### DIFF
--- a/petprep/interfaces/segmentation.py
+++ b/petprep/interfaces/segmentation.py
@@ -209,12 +209,21 @@ class SegmentHA_T1(FSCommand):
             runtime.returncode = 0
             return runtime
 
-        cmd = CommandLine(
-            command='segmentHA_T1.sh',
-            args=self.inputs.subject_id,
-            environ={'SUBJECTS_DIR': self.inputs.subjects_dir},
+        cmd = [
+            'segmentHA_T1.sh',
+            self.inputs.subject_id,
+            str(self.inputs.subjects_dir),
+        ]
+        proc = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            env={**os.environ, **runtime.environ, 'SUBJECTS_DIR': str(self.inputs.subjects_dir)},
         )
-        runtime = cmd.run()
+        runtime.stdout = proc.stdout
+        runtime.stderr = proc.stderr
+        runtime.returncode = proc.returncode
 
         return runtime
 

--- a/petprep/interfaces/tests/test_segmentation_interface.py
+++ b/petprep/interfaces/tests/test_segmentation_interface.py
@@ -2,7 +2,14 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from ... import config
-from ..segmentation import MRISclimbicSeg, SegmentBS, SegmentGTM, SegmentWM, _set_freesurfer_seed
+from ..segmentation import (
+    MRISclimbicSeg,
+    SegmentBS,
+    SegmentGTM,
+    SegmentHA_T1,
+    SegmentWM,
+    _set_freesurfer_seed,
+)
 
 
 def test_segmentgtm_skip(tmp_path):
@@ -75,3 +82,54 @@ def test_set_freesurfer_seed_runtime():
     runtime = _set_freesurfer_seed(runtime)
 
     assert runtime.environ['FREESURFER_RANDOM_SEED'] == str(config.seeds.freesurfer)
+
+
+def test_segmentha_t1_uses_explicit_subjects_dir(monkeypatch, tmp_path):
+    subject_dir = tmp_path / 'sub-01'
+    (subject_dir / 'mri').mkdir(parents=True)
+
+    captured = {}
+
+    def _fake_run(cmd, check, capture_output, text, env):
+        captured['cmd'] = cmd
+        captured['env'] = env
+        out_dir = tmp_path / 'sub-01' / 'mri'
+        for out in (
+            'lh.hippoAmygLabels-T1.v22.FSvoxelSpace.mgz',
+            'rh.hippoAmygLabels-T1.v22.FSvoxelSpace.mgz',
+            'lh.hippoSfVolumes-T1.v22.txt',
+            'lh.amygNucVolumes-T1.v22.txt',
+            'rh.hippoSfVolumes-T1.v22.txt',
+            'rh.amygNucVolumes-T1.v22.txt',
+        ):
+            (out_dir / out).write_text('')
+        return SimpleNamespace(stdout='ok', stderr='', returncode=0)
+
+    monkeypatch.setattr('petprep.interfaces.segmentation.subprocess.run', _fake_run)
+
+    seg = SegmentHA_T1(subjects_dir=str(tmp_path), subject_id='sub-01')
+    res = seg.run()
+
+    assert captured['cmd'] == ['segmentHA_T1.sh', 'sub-01', str(tmp_path)]
+    assert captured['env']['SUBJECTS_DIR'] == str(tmp_path)
+    assert res.runtime.returncode == 0
+
+
+def test_segmentha_t1_skips_when_outputs_exist(tmp_path):
+    subj_dir = tmp_path / 'sub-01' / 'mri'
+    subj_dir.mkdir(parents=True)
+    for out in (
+        'lh.hippoAmygLabels-T1.v22.FSvoxelSpace.mgz',
+        'rh.hippoAmygLabels-T1.v22.FSvoxelSpace.mgz',
+        'lh.hippoSfVolumes-T1.v22.txt',
+        'lh.amygNucVolumes-T1.v22.txt',
+        'rh.hippoSfVolumes-T1.v22.txt',
+        'rh.amygNucVolumes-T1.v22.txt',
+    ):
+        (subj_dir / out).write_text('')
+
+    seg = SegmentHA_T1(subjects_dir=str(tmp_path), subject_id='sub-01')
+    res = seg.run()
+
+    assert res.runtime.returncode == 0
+    assert Path(res.outputs.lh_hippoAmygLabels) == subj_dir / 'lh.hippoAmygLabels-T1.v22.FSvoxelSpace.mgz'


### PR DESCRIPTION
### Motivation
- The `SegmentHA_T1` interface could invoke `segmentHA_T1.sh` without the explicit `subjects_dir` argument or environment, causing the tool to run against the wrong FreeSurfer directory and resulting in missing expected outputs and node failures. 
- The change aims to ensure PETPrep respects the configured FreeSurfer `subjects_dir` (for example `/opt/subjects`) rather than inheriting system FreeSurfer defaults.

### Description
- Updated `SegmentHA_T1._run_interface` to call `segmentHA_T1.sh` via `subprocess.run` with both `subject_id` and `subjects_dir` arguments and to explicitly set `SUBJECTS_DIR` in the subprocess environment. 
- Captured `stdout`, `stderr`, and `returncode` from the subprocess and propagated them to the `runtime` object for consistent runtime reporting. 
- Added tests `test_segmentha_t1_uses_explicit_subjects_dir` and `test_segmentha_t1_skips_when_outputs_exist` and imported `SegmentHA_T1` into the segmentation test module to cover the new behavior. 
- Files changed: `petprep/interfaces/segmentation.py` and `petprep/interfaces/tests/test_segmentation_interface.py`.

### Testing
- Running `pytest -q petprep/interfaces/tests/test_segmentation_interface.py` initially failed due to repository `addopts` injecting coverage flags not available in this environment. 
- Running `pytest -q -o addopts='' petprep/interfaces/tests/test_segmentation_interface.py` succeeded with `7 passed` and `2 warnings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4a47e52c8330983e992431ee9b3b)