### PR TITLE
Add PVC metadata to TAC sidecar JSON outputs

### DIFF
--- a/petprep/workflows/pet/base.py
+++ b/petprep/workflows/pet/base.py
@@ -30,6 +30,7 @@ Orchestrating the PET-preprocessing workflow
 
 """
 
+import sys
 from pathlib import Path
 
 from nipype.interfaces import utility as niu
@@ -47,6 +48,7 @@ from .apply import init_pet_volumetric_resample_wf
 from .confounds import init_carpetplot_wf, init_pet_confs_wf
 from .fit import init_pet_fit_wf, init_pet_native_wf
 from .outputs import (
+    build_pvc_tacs_dict,
     build_psf_dict,
     init_ds_pet_native_wf,
     init_ds_volumes_wf,
@@ -361,6 +363,9 @@ configured with cubic B-spline interpolation.
     pvc_method = getattr(config.workflow, 'pvc_method', None)
     pvc_psf = getattr(config.workflow, 'pvc_psf', None)
     run_pvc = pvc_tool is not None and pvc_method is not None and pvc_psf is not None
+    tacs_fwhm_x = None
+    tacs_fwhm_y = None
+    tacs_fwhm_z = None
 
     if run_pvc:
         try:
@@ -376,6 +381,7 @@ configured with cubic B-spline interpolation.
                 psf_vals = psf_vals * 3
             if len(psf_vals) != 3:
                 raise ValueError('PETPVC requires one or three PSF values (FWHM x/y/z).')
+            tacs_fwhm_x, tacs_fwhm_y, tacs_fwhm_z = psf_vals
             pvc_kwargs = {
                 'fwhm_x': psf_vals[0],
                 'fwhm_y': psf_vals[1],
@@ -383,6 +389,7 @@ configured with cubic B-spline interpolation.
             }
         else:
             # PETSurfer only accepts an isotropic PSF
+            tacs_fwhm_x = tacs_fwhm_y = tacs_fwhm_z = float(pvc_psf[0])
             pvc_kwargs = {'psf': float(pvc_psf[0])}
 
         pet_pvc_wf = init_pet_pvc_wf(
@@ -742,6 +749,14 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
     ds_pet_tacs.inputs.source_file = pet_file
     if pvc_method is not None:
         ds_pet_tacs.inputs.pvc = pvc_method
+        ds_pet_tacs.inputs.meta_dict = build_pvc_tacs_dict(
+            pvc_method=pvc_method,
+            fwhm_x=tacs_fwhm_x,
+            fwhm_y=tacs_fwhm_y,
+            fwhm_z=tacs_fwhm_z,
+            software_name=pvc_tool,
+            command_line=' '.join(sys.argv),
+        )
 
     workflow.connect([
         (pet_t1w_src, pet_tacs_wf, [(pet_t1w_field, 'inputnode.pet_anat')]),
@@ -776,6 +791,14 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         ds_ref_tacs.inputs.source_file = pet_file
         if pvc_method is not None:
             ds_ref_tacs.inputs.pvc = pvc_method
+            ds_ref_tacs.inputs.meta_dict = build_pvc_tacs_dict(
+                pvc_method=pvc_method,
+                fwhm_x=tacs_fwhm_x,
+                fwhm_y=tacs_fwhm_y,
+                fwhm_z=tacs_fwhm_z,
+                software_name=pvc_tool,
+                command_line=' '.join(sys.argv),
+            )
 
         workflow.connect([
             (pet_t1w_src, pet_ref_tacs_wf, [(pet_t1w_field, 'inputnode.pet_anat')]),

--- a/petprep/workflows/pet/outputs.py
+++ b/petprep/workflows/pet/outputs.py
@@ -86,6 +86,38 @@ def build_psf_dict(fwhm_x=None, fwhm_y=None, fwhm_z=None):
     }
 
 
+def build_pvc_tacs_dict(
+    *,
+    pvc_method: str | None,
+    fwhm_x: float | None = None,
+    fwhm_y: float | None = None,
+    fwhm_z: float | None = None,
+    software_name: str | None = None,
+    software_version: str | None = None,
+    command_line: str | None = None,
+):
+    """Construct PVC metadata for TAC sidecars."""
+    if pvc_method is None:
+        return {}
+
+    meta = {'PVCMethod': str(pvc_method)}
+
+    if fwhm_x is not None:
+        meta['FWHM_x'] = float(fwhm_x)
+    if fwhm_y is not None:
+        meta['FWHM_y'] = float(fwhm_y)
+    if fwhm_z is not None:
+        meta['FWHM_z'] = float(fwhm_z)
+    if software_name:
+        meta['SoftwareName'] = str(software_name).lower()
+    if software_version:
+        meta['SoftwareVersion'] = str(software_version)
+    if command_line:
+        meta['CommandLine'] = str(command_line)
+
+    return meta
+
+
 def init_func_fit_reports_wf(
     *,
     freesurfer: bool,

--- a/petprep/workflows/pet/tests/test_base.py
+++ b/petprep/workflows/pet/tests/test_base.py
@@ -144,9 +144,23 @@ def test_pvc_entity_added(bids_root: Path):
         assert wf.get_node('ds_pet_cifti').inputs.pvc == pvc_method
 
     assert wf.get_node('ds_pet_tacs').inputs.pvc == pvc_method
+    pet_tacs_meta = wf.get_node('ds_pet_tacs').inputs.meta_dict
+    assert pet_tacs_meta['PVCMethod'] == pvc_method
+    assert pet_tacs_meta['FWHM_x'] == 1.0
+    assert pet_tacs_meta['FWHM_y'] == 1.0
+    assert pet_tacs_meta['FWHM_z'] == 1.0
+    assert pet_tacs_meta['SoftwareName'] == 'petpvc'
+    assert 'CommandLine' in pet_tacs_meta
 
     if 'ds_ref_tacs' in wf.list_node_names():
         assert wf.get_node('ds_ref_tacs').inputs.pvc == pvc_method
+        ref_tacs_meta = wf.get_node('ds_ref_tacs').inputs.meta_dict
+        assert ref_tacs_meta['PVCMethod'] == pvc_method
+        assert ref_tacs_meta['FWHM_x'] == 1.0
+        assert ref_tacs_meta['FWHM_y'] == 1.0
+        assert ref_tacs_meta['FWHM_z'] == 1.0
+        assert ref_tacs_meta['SoftwareName'] == 'petpvc'
+        assert 'CommandLine' in ref_tacs_meta
 
 
 def test_pvc_used_in_std_space(bids_root: Path):

--- a/petprep/workflows/pet/tests/test_outputs.py
+++ b/petprep/workflows/pet/tests/test_outputs.py
@@ -96,7 +96,7 @@ def test_refmask_sources(tmp_path: Path):
 def test_prepare_timing_parameters_and_psf_metadata():
     from nipype.interfaces.base import Undefined
 
-    from ..outputs import build_psf_dict, prepare_timing_parameters
+    from ..outputs import build_psf_dict, build_pvc_tacs_dict, prepare_timing_parameters
 
     timing = prepare_timing_parameters(
         {
@@ -118,6 +118,25 @@ def test_prepare_timing_parameters_and_psf_metadata():
     assert build_psf_dict(3, 4.5, 5) == {'fwhm_x': 3.0, 'fwhm_y': 4.5, 'fwhm_z': 5.0}
     assert build_psf_dict(Undefined, 4.5, 5) == {}
     assert build_psf_dict(None, 4.5, 5) == {}
+
+    assert build_pvc_tacs_dict(pvc_method=None) == {}
+    assert build_pvc_tacs_dict(
+        pvc_method='GTM',
+        fwhm_x=3,
+        fwhm_y=4.5,
+        fwhm_z=5,
+        software_name='PETPVC',
+        software_version='1.2.3',
+        command_line='petprep /bids /out participant',
+    ) == {
+        'PVCMethod': 'GTM',
+        'FWHM_x': 3.0,
+        'FWHM_y': 4.5,
+        'FWHM_z': 5.0,
+        'SoftwareName': 'petpvc',
+        'SoftwareVersion': '1.2.3',
+        'CommandLine': 'petprep /bids /out participant',
+    }
 
 
 def test_init_func_fit_reports_wf_with_atlas_and_refmask(tmp_path: Path):


### PR DESCRIPTION
### Motivation

- Ensure TAC sidecar JSON files include PVC choices and derived PSF parameters when PVC is run so downstream consumers can trace how TACs were generated. 
- Record PVC tool and invocation details (`SoftwareName`, `SoftwareVersion`, `CommandLine`) alongside `PVCMethod` and per-axis `FWHM_x/FWHM_y/FWHM_z` for provenance.

### Description

- Add a new helper `build_pvc_tacs_dict(...)` in `petprep/workflows/pet/outputs.py` to construct PVC metadata for TAC sidecars (keys: `PVCMethod`, `FWHM_x`, `FWHM_y`, `FWHM_z`, `SoftwareName`, `SoftwareVersion`, `CommandLine`).
- Wire PVC metadata into TAC datasinks by setting `ds_pet_tacs.inputs.meta_dict` and `ds_ref_tacs.inputs.meta_dict` in `petprep/workflows/pet/base.py` when PVC is enabled, and capture command-line via `sys.argv`.
- Preserve correct PSF handling for both `PETPVC` (accepts 1 or 3 FWHM values; expanded if single) and `PETSurfer` (isotropic PSF propagated to x/y/z), and normalize `SoftwareName` to lowercase.
- Add/adjust tests in `petprep/workflows/pet/tests/test_outputs.py` and `petprep/workflows/pet/tests/test_base.py` to validate `build_pvc_tacs_dict` and that TAC datasinks receive the PVC metadata.

### Testing

- Compiled modified modules with `python -m compileall petprep/workflows/pet/base.py petprep/workflows/pet/outputs.py` which succeeded.
- Ran `pytest -q -o addopts='' petprep/workflows/pet/tests/test_outputs.py::test_prepare_timing_parameters_and_psf_metadata` which passed locally.
- Ran `pytest -q -o addopts='' petprep/workflows/pet/tests/test_base.py::test_pvc_entity_added` which exercised the new datasink metadata assertions but failed in this CI environment due to a blocked TemplateFlow download caused by a network/proxy restriction rather than the code change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0a00928e083308dc69dcc0f6dabe2)