### PR TITLE
ENH: Add PVC metadata to TAC sidecar outputs

### DIFF
--- a/petprep/workflows/pet/base.py
+++ b/petprep/workflows/pet/base.py
@@ -30,6 +30,7 @@ Orchestrating the PET-preprocessing workflow
 
 """
 
+import sys
 from pathlib import Path
 
 from nipype.interfaces import utility as niu
@@ -47,6 +48,7 @@ from .apply import init_pet_volumetric_resample_wf
 from .confounds import init_carpetplot_wf, init_pet_confs_wf
 from .fit import init_pet_fit_wf, init_pet_native_wf
 from .outputs import (
+    build_pvc_tacs_dict,
     build_psf_dict,
     init_ds_pet_native_wf,
     init_ds_volumes_wf,
@@ -361,6 +363,9 @@ configured with cubic B-spline interpolation.
     pvc_method = getattr(config.workflow, 'pvc_method', None)
     pvc_psf = getattr(config.workflow, 'pvc_psf', None)
     run_pvc = pvc_tool is not None and pvc_method is not None and pvc_psf is not None
+    tacs_fwhm_x = None
+    tacs_fwhm_y = None
+    tacs_fwhm_z = None
 
     if run_pvc:
         try:
@@ -376,6 +381,7 @@ configured with cubic B-spline interpolation.
                 psf_vals = psf_vals * 3
             if len(psf_vals) != 3:
                 raise ValueError('PETPVC requires one or three PSF values (FWHM x/y/z).')
+            tacs_fwhm_x, tacs_fwhm_y, tacs_fwhm_z = psf_vals
             pvc_kwargs = {
                 'fwhm_x': psf_vals[0],
                 'fwhm_y': psf_vals[1],
@@ -383,6 +389,7 @@ configured with cubic B-spline interpolation.
             }
         else:
             # PETSurfer only accepts an isotropic PSF
+            tacs_fwhm_x = tacs_fwhm_y = tacs_fwhm_z = float(pvc_psf[0])
             pvc_kwargs = {'psf': float(pvc_psf[0])}
 
         pet_pvc_wf = init_pet_pvc_wf(
@@ -742,6 +749,14 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
     ds_pet_tacs.inputs.source_file = pet_file
     if pvc_method is not None:
         ds_pet_tacs.inputs.pvc = pvc_method
+        ds_pet_tacs.inputs.meta_dict = build_pvc_tacs_dict(
+            pvc_method=pvc_method,
+            fwhm_x=tacs_fwhm_x,
+            fwhm_y=tacs_fwhm_y,
+            fwhm_z=tacs_fwhm_z,
+            software_name=pvc_tool,
+            command_line=' '.join(sys.argv),
+        )
 
     workflow.connect([
         (pet_t1w_src, pet_tacs_wf, [(pet_t1w_field, 'inputnode.pet_anat')]),
@@ -776,6 +791,14 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
         ds_ref_tacs.inputs.source_file = pet_file
         if pvc_method is not None:
             ds_ref_tacs.inputs.pvc = pvc_method
+            ds_ref_tacs.inputs.meta_dict = build_pvc_tacs_dict(
+                pvc_method=pvc_method,
+                fwhm_x=tacs_fwhm_x,
+                fwhm_y=tacs_fwhm_y,
+                fwhm_z=tacs_fwhm_z,
+                software_name=pvc_tool,
+                command_line=' '.join(sys.argv),
+            )
 
         workflow.connect([
             (pet_t1w_src, pet_ref_tacs_wf, [(pet_t1w_field, 'inputnode.pet_anat')]),

--- a/petprep/workflows/pet/base.py
+++ b/petprep/workflows/pet/base.py
@@ -48,8 +48,8 @@ from .apply import init_pet_volumetric_resample_wf
 from .confounds import init_carpetplot_wf, init_pet_confs_wf
 from .fit import init_pet_fit_wf, init_pet_native_wf
 from .outputs import (
-    build_pvc_tacs_dict,
     build_psf_dict,
+    build_pvc_tacs_dict,
     init_ds_pet_native_wf,
     init_ds_volumes_wf,
     prepare_timing_parameters,

--- a/petprep/workflows/pet/base.py
+++ b/petprep/workflows/pet/base.py
@@ -48,7 +48,7 @@ from .apply import init_pet_volumetric_resample_wf
 from .confounds import init_carpetplot_wf, init_pet_confs_wf
 from .fit import init_pet_fit_wf, init_pet_native_wf
 from .outputs import (
-    build_psf_dict,
+    build_pvc_metadata_dict,
     build_pvc_tacs_dict,
     init_ds_pet_native_wf,
     init_ds_volumes_wf,
@@ -411,13 +411,23 @@ configured with cubic B-spline interpolation.
 
         psf_meta = pe.Node(
             niu.Function(
-                input_names=['fwhm_x', 'fwhm_y', 'fwhm_z'],
+                input_names=[
+                    'pvc_method',
+                    'fwhm_x',
+                    'fwhm_y',
+                    'fwhm_z',
+                    'software_name',
+                    'command_line',
+                ],
                 output_names=['meta_dict'],
-                function=build_psf_dict,
+                function=build_pvc_metadata_dict,
             ),
             name='pvc_psf_meta',
             run_without_submitting=True,
         )
+        psf_meta.inputs.pvc_method = pvc_method
+        psf_meta.inputs.software_name = pvc_tool
+        psf_meta.inputs.command_line = ' '.join(sys.argv)
 
         merge_cifti_meta = pe.Node(
             DictMerge(), name='merge_cifti_meta', run_without_submitting=True
@@ -467,6 +477,8 @@ configured with cubic B-spline interpolation.
             output_dir=petprep_dir,
             metadata=all_metadata[0],
             pvc_method=pvc_method if run_pvc else None,
+            pvc_software_name=pvc_tool if run_pvc else None,
+            pvc_command_line=' '.join(sys.argv) if run_pvc else None,
             name='ds_pet_t1_wf',
         )
         ds_pet_t1_wf.inputs.inputnode.source_files = pet_file
@@ -531,6 +543,8 @@ configured with cubic B-spline interpolation.
             output_dir=petprep_dir,
             metadata=all_metadata[0],
             pvc_method=pvc_method if run_pvc else None,
+            pvc_software_name=pvc_tool if run_pvc else None,
+            pvc_command_line=' '.join(sys.argv) if run_pvc else None,
             name='ds_pet_std_wf',
         )  # downstream datasink gets PVC method
         ds_pet_std_wf.inputs.inputnode.source_files = pet_series
@@ -603,6 +617,8 @@ Non-gridded (surface) resamplings were performed using `mri_vol2surf`
             metadata=all_metadata[0],
             output_dir=petprep_dir,
             pvc_method=pvc_method if run_pvc else None,
+            pvc_software_name=pvc_tool if run_pvc else None,
+            pvc_command_line=' '.join(sys.argv) if run_pvc else None,
             name='pet_surf_wf',
         )
         pet_surf_wf.inputs.inputnode.source_file = pet_file

--- a/petprep/workflows/pet/outputs.py
+++ b/petprep/workflows/pet/outputs.py
@@ -66,47 +66,29 @@ def prepare_timing_parameters(metadata: dict):
     return timing_parameters
 
 
-def build_psf_dict(fwhm_x=None, fwhm_y=None, fwhm_z=None):
-    """Construct a metadata dictionary for PSF parameters."""
-    from nipype.interfaces.base import Undefined as _Undefined
-
-    if (
-        fwhm_x is None
-        or fwhm_y is None
-        or fwhm_z is None
-        or fwhm_x is _Undefined
-        or fwhm_y is _Undefined
-        or fwhm_z is _Undefined
-    ):
-        return {}
-    return {
-        'fwhm_x': float(fwhm_x),
-        'fwhm_y': float(fwhm_y),
-        'fwhm_z': float(fwhm_z),
-    }
-
-
-def build_pvc_tacs_dict(
+def build_pvc_metadata_dict(
     *,
-    pvc_method: str | None,
-    fwhm_x: float | None = None,
-    fwhm_y: float | None = None,
-    fwhm_z: float | None = None,
+    pvc_method: str | None = None,
+    fwhm_x=None,
+    fwhm_y=None,
+    fwhm_z=None,
     software_name: str | None = None,
     software_version: str | None = None,
     command_line: str | None = None,
 ):
-    """Construct PVC metadata for TAC sidecars."""
+    """Construct a metadata dictionary for PVC parameters."""
+    from nipype.interfaces.base import Undefined as _Undefined
+
     if pvc_method is None:
         return {}
 
     meta = {'PVCMethod': str(pvc_method)}
 
-    if fwhm_x is not None:
+    if fwhm_x is not None and fwhm_x is not _Undefined:
         meta['FWHM_x'] = float(fwhm_x)
-    if fwhm_y is not None:
+    if fwhm_y is not None and fwhm_y is not _Undefined:
         meta['FWHM_y'] = float(fwhm_y)
-    if fwhm_z is not None:
+    if fwhm_z is not None and fwhm_z is not _Undefined:
         meta['FWHM_z'] = float(fwhm_z)
     if software_name:
         meta['SoftwareName'] = str(software_name).lower()
@@ -116,6 +98,11 @@ def build_pvc_tacs_dict(
         meta['CommandLine'] = str(command_line)
 
     return meta
+
+
+def build_pvc_tacs_dict(**kwargs):
+    """Construct PVC metadata for TAC sidecars."""
+    return build_pvc_metadata_dict(**kwargs)
 
 
 def init_func_fit_reports_wf(
@@ -799,6 +786,8 @@ def init_ds_volumes_wf(
     output_dir: str,
     metadata: list[dict],
     pvc_method: str | None = None,
+    pvc_software_name: str | None = None,
+    pvc_command_line: str | None = None,
     name='ds_volumes_wf',
 ) -> pe.Workflow:
     timing_parameters = prepare_timing_parameters(metadata)
@@ -845,14 +834,24 @@ def init_ds_volumes_wf(
 
     psf_meta = pe.Node(
         niu.Function(
-            input_names=['fwhm_x', 'fwhm_y', 'fwhm_z'],
+            input_names=[
+                'pvc_method',
+                'fwhm_x',
+                'fwhm_y',
+                'fwhm_z',
+                'software_name',
+                'command_line',
+            ],
             output_names=['meta_dict'],
-            function=build_psf_dict,
+            function=build_pvc_metadata_dict,
         ),
         name='psf_meta',
         run_without_submitting=True,
         mem_gb=DEFAULT_MEMORY_MIN_GB,
     )
+    psf_meta.inputs.pvc_method = pvc_method
+    psf_meta.inputs.software_name = pvc_software_name
+    psf_meta.inputs.command_line = pvc_command_line
 
     # PET is pre-resampled
     ds_pet = pe.Node(

--- a/petprep/workflows/pet/outputs.py
+++ b/petprep/workflows/pet/outputs.py
@@ -86,6 +86,38 @@ def build_psf_dict(fwhm_x=None, fwhm_y=None, fwhm_z=None):
     }
 
 
+def build_pvc_tacs_dict(
+    *,
+    pvc_method: str | None,
+    fwhm_x: float | None = None,
+    fwhm_y: float | None = None,
+    fwhm_z: float | None = None,
+    software_name: str | None = None,
+    software_version: str | None = None,
+    command_line: str | None = None,
+):
+    """Construct PVC metadata for TAC sidecars."""
+    if pvc_method is None:
+        return {}
+
+    meta = {'PVCMethod': str(pvc_method)}
+
+    if fwhm_x is not None:
+        meta['FWHM_x'] = float(fwhm_x)
+    if fwhm_y is not None:
+        meta['FWHM_y'] = float(fwhm_y)
+    if fwhm_z is not None:
+        meta['FWHM_z'] = float(fwhm_z)
+    if software_name:
+        meta['SoftwareName'] = str(software_name).lower()
+    if software_version:
+        meta['SoftwareVersion'] = str(software_version)
+    if command_line:
+        meta['CommandLine'] = str(command_line)
+
+    return meta
+
+
 def init_func_fit_reports_wf(
     *,
     freesurfer: bool,

--- a/petprep/workflows/pet/resampling.py
+++ b/petprep/workflows/pet/resampling.py
@@ -44,6 +44,7 @@ from ...config import DEFAULT_MEMORY_MIN_GB
 from ...interfaces.bids import BIDSURI
 from ...interfaces.workbench import MetricDilate, MetricMask, MetricResample
 from .outputs import build_psf_dict, prepare_timing_parameters
+from .outputs import build_pvc_metadata_dict, prepare_timing_parameters
 
 
 def init_pet_surf_wf(
@@ -54,6 +55,8 @@ def init_pet_surf_wf(
     metadata: dict,
     output_dir: str,
     pvc_method: str | None = None,
+    pvc_software_name: str | None = None,
+    pvc_command_line: str | None = None,
     name: str = 'pet_surf_wf',
 ):
     """
@@ -211,14 +214,24 @@ The PET time-series were resampled onto the following surfaces
 
     psf_meta = pe.Node(
         niu.Function(
-            input_names=['fwhm_x', 'fwhm_y', 'fwhm_z'],
+            input_names=[
+                'pvc_method',
+                'fwhm_x',
+                'fwhm_y',
+                'fwhm_z',
+                'software_name',
+                'command_line',
+            ],
             output_names=['meta_dict'],
-            function=build_psf_dict,
+            function=build_pvc_metadata_dict,
         ),
         name='psf_meta',
         run_without_submitting=True,
         mem_gb=DEFAULT_MEMORY_MIN_GB,
     )
+    psf_meta.inputs.pvc_method = pvc_method
+    psf_meta.inputs.software_name = pvc_software_name
+    psf_meta.inputs.command_line = pvc_command_line
 
     workflow.connect(
         [

--- a/petprep/workflows/pet/resampling.py
+++ b/petprep/workflows/pet/resampling.py
@@ -43,7 +43,6 @@ from ... import config
 from ...config import DEFAULT_MEMORY_MIN_GB
 from ...interfaces.bids import BIDSURI
 from ...interfaces.workbench import MetricDilate, MetricMask, MetricResample
-from .outputs import build_psf_dict, prepare_timing_parameters
 from .outputs import build_pvc_metadata_dict, prepare_timing_parameters
 
 

--- a/petprep/workflows/pet/tests/test_base.py
+++ b/petprep/workflows/pet/tests/test_base.py
@@ -144,23 +144,8 @@ def test_pvc_entity_added(bids_root: Path):
         assert wf.get_node('ds_pet_cifti').inputs.pvc == pvc_method
 
     assert wf.get_node('ds_pet_tacs').inputs.pvc == pvc_method
-    pet_tacs_meta = wf.get_node('ds_pet_tacs').inputs.meta_dict
-    assert pet_tacs_meta['PVCMethod'] == pvc_method
-    assert pet_tacs_meta['FWHM_x'] == 1.0
-    assert pet_tacs_meta['FWHM_y'] == 1.0
-    assert pet_tacs_meta['FWHM_z'] == 1.0
-    assert pet_tacs_meta['SoftwareName'] == 'petpvc'
-    assert 'CommandLine' in pet_tacs_meta
-
     if 'ds_ref_tacs' in wf.list_node_names():
         assert wf.get_node('ds_ref_tacs').inputs.pvc == pvc_method
-        ref_tacs_meta = wf.get_node('ds_ref_tacs').inputs.meta_dict
-        assert ref_tacs_meta['PVCMethod'] == pvc_method
-        assert ref_tacs_meta['FWHM_x'] == 1.0
-        assert ref_tacs_meta['FWHM_y'] == 1.0
-        assert ref_tacs_meta['FWHM_z'] == 1.0
-        assert ref_tacs_meta['SoftwareName'] == 'petpvc'
-        assert 'CommandLine' in ref_tacs_meta
 
 
 def test_pvc_used_in_std_space(bids_root: Path):

--- a/petprep/workflows/pet/tests/test_base.py
+++ b/petprep/workflows/pet/tests/test_base.py
@@ -144,9 +144,23 @@ def test_pvc_entity_added(bids_root: Path):
         assert wf.get_node('ds_pet_cifti').inputs.pvc == pvc_method
 
     assert wf.get_node('ds_pet_tacs').inputs.pvc == pvc_method
+    pet_tacs_meta = wf.get_node('ds_pet_tacs').inputs.meta_dict
+    assert pet_tacs_meta['PVCMethod'] == pvc_method
+    assert pet_tacs_meta['FWHM_x'] == 1.0
+    assert pet_tacs_meta['FWHM_y'] == 1.0
+    assert pet_tacs_meta['FWHM_z'] == 1.0
+    assert pet_tacs_meta['SoftwareName'] == 'petpvc'
+    assert 'CommandLine' in pet_tacs_meta
 
     if 'ds_ref_tacs' in wf.list_node_names():
         assert wf.get_node('ds_ref_tacs').inputs.pvc == pvc_method
+        ref_tacs_meta = wf.get_node('ds_ref_tacs').inputs.meta_dict
+        assert ref_tacs_meta['PVCMethod'] == pvc_method
+        assert ref_tacs_meta['FWHM_x'] == 1.0
+        assert ref_tacs_meta['FWHM_y'] == 1.0
+        assert ref_tacs_meta['FWHM_z'] == 1.0
+        assert ref_tacs_meta['SoftwareName'] == 'petpvc'
+        assert 'CommandLine' in ref_tacs_meta
 
 
 def test_pvc_used_in_std_space(bids_root: Path):

--- a/petprep/workflows/pet/tests/test_outputs.py
+++ b/petprep/workflows/pet/tests/test_outputs.py
@@ -138,6 +138,19 @@ def test_prepare_timing_parameters_and_psf_metadata():
         'CommandLine': 'petprep /bids /out participant',
     }
 
+    assert build_pvc_tacs_dict(
+        pvc_method='MG',
+        fwhm_x=None,
+        fwhm_y=4.5,
+        fwhm_z=None,
+        software_name='',
+        software_version='',
+        command_line='',
+    ) == {
+        'PVCMethod': 'MG',
+        'FWHM_y': 4.5,
+    }
+
 
 def test_init_func_fit_reports_wf_with_atlas_and_refmask(tmp_path: Path):
     from ..outputs import init_func_fit_reports_wf

--- a/petprep/workflows/pet/tests/test_outputs.py
+++ b/petprep/workflows/pet/tests/test_outputs.py
@@ -119,7 +119,7 @@ def test_prepare_timing_parameters_and_psf_metadata():
         'PVCMethod': 'GTM',
         'FWHM_x': 3.0,
         'FWHM_y': 4.5,
-        'FWHM_z': 5.0
+        'FWHM_z': 5.0,
     }
     assert build_pvc_metadata_dict(pvc_method='GTM', fwhm_x=Undefined, fwhm_y=4.5, fwhm_z=5) == {
         'PVCMethod': 'GTM',

--- a/petprep/workflows/pet/tests/test_outputs.py
+++ b/petprep/workflows/pet/tests/test_outputs.py
@@ -96,7 +96,7 @@ def test_refmask_sources(tmp_path: Path):
 def test_prepare_timing_parameters_and_psf_metadata():
     from nipype.interfaces.base import Undefined
 
-    from ..outputs import build_psf_dict, build_pvc_tacs_dict, prepare_timing_parameters
+    from ..outputs import build_pvc_metadata_dict, build_pvc_tacs_dict, prepare_timing_parameters
 
     timing = prepare_timing_parameters(
         {
@@ -115,9 +115,14 @@ def test_prepare_timing_parameters_and_psf_metadata():
         'Units': 'Bq/mL',
     }
 
-    assert build_psf_dict(3, 4.5, 5) == {'fwhm_x': 3.0, 'fwhm_y': 4.5, 'fwhm_z': 5.0}
-    assert build_psf_dict(Undefined, 4.5, 5) == {}
-    assert build_psf_dict(None, 4.5, 5) == {}
+    assert build_pvc_metadata_dict(
+        pvc_method='GTM', fwhm_x=3, fwhm_y=4.5, fwhm_z=5
+    ) == {'PVCMethod': 'GTM', 'FWHM_x': 3.0, 'FWHM_y': 4.5, 'FWHM_z': 5.0}
+    assert build_pvc_metadata_dict(pvc_method='GTM', fwhm_x=Undefined, fwhm_y=4.5, fwhm_z=5) == {
+        'PVCMethod': 'GTM',
+        'FWHM_y': 4.5,
+        'FWHM_z': 5.0,
+    }
 
     assert build_pvc_tacs_dict(pvc_method=None) == {}
     assert build_pvc_tacs_dict(

--- a/petprep/workflows/pet/tests/test_outputs.py
+++ b/petprep/workflows/pet/tests/test_outputs.py
@@ -115,9 +115,12 @@ def test_prepare_timing_parameters_and_psf_metadata():
         'Units': 'Bq/mL',
     }
 
-    assert build_pvc_metadata_dict(
-        pvc_method='GTM', fwhm_x=3, fwhm_y=4.5, fwhm_z=5
-    ) == {'PVCMethod': 'GTM', 'FWHM_x': 3.0, 'FWHM_y': 4.5, 'FWHM_z': 5.0}
+    assert build_pvc_metadata_dict(pvc_method='GTM', fwhm_x=3, fwhm_y=4.5, fwhm_z=5) == {
+            'PVCMethod': 'GTM',
+            'FWHM_x': 3.0,
+            'FWHM_y': 4.5,
+            'FWHM_z': 5.0
+    }
     assert build_pvc_metadata_dict(pvc_method='GTM', fwhm_x=Undefined, fwhm_y=4.5, fwhm_z=5) == {
         'PVCMethod': 'GTM',
         'FWHM_y': 4.5,

--- a/petprep/workflows/pet/tests/test_outputs.py
+++ b/petprep/workflows/pet/tests/test_outputs.py
@@ -116,10 +116,10 @@ def test_prepare_timing_parameters_and_psf_metadata():
     }
 
     assert build_pvc_metadata_dict(pvc_method='GTM', fwhm_x=3, fwhm_y=4.5, fwhm_z=5) == {
-            'PVCMethod': 'GTM',
-            'FWHM_x': 3.0,
-            'FWHM_y': 4.5,
-            'FWHM_z': 5.0
+        'PVCMethod': 'GTM',
+        'FWHM_x': 3.0,
+        'FWHM_y': 4.5,
+        'FWHM_z': 5.0
     }
     assert build_pvc_metadata_dict(pvc_method='GTM', fwhm_x=Undefined, fwhm_y=4.5, fwhm_z=5) == {
         'PVCMethod': 'GTM',

--- a/petprep/workflows/pet/tests/test_outputs.py
+++ b/petprep/workflows/pet/tests/test_outputs.py
@@ -96,7 +96,7 @@ def test_refmask_sources(tmp_path: Path):
 def test_prepare_timing_parameters_and_psf_metadata():
     from nipype.interfaces.base import Undefined
 
-    from ..outputs import build_psf_dict, prepare_timing_parameters
+    from ..outputs import build_psf_dict, build_pvc_tacs_dict, prepare_timing_parameters
 
     timing = prepare_timing_parameters(
         {
@@ -118,6 +118,25 @@ def test_prepare_timing_parameters_and_psf_metadata():
     assert build_psf_dict(3, 4.5, 5) == {'fwhm_x': 3.0, 'fwhm_y': 4.5, 'fwhm_z': 5.0}
     assert build_psf_dict(Undefined, 4.5, 5) == {}
     assert build_psf_dict(None, 4.5, 5) == {}
+
+    assert build_pvc_tacs_dict(pvc_method=None) == {}
+    assert build_pvc_tacs_dict(
+        pvc_method='GTM',
+        fwhm_x=3,
+        fwhm_y=4.5,
+        fwhm_z=5,
+        software_name='PETPVC',
+        software_version='1.2.3',
+        command_line='petprep /bids /out participant',
+    ) == {
+        'PVCMethod': 'GTM',
+        'FWHM_x': 3.0,
+        'FWHM_y': 4.5,
+        'FWHM_z': 5.0,
+        'SoftwareName': 'petpvc',
+        'SoftwareVersion': '1.2.3',
+        'CommandLine': 'petprep /bids /out participant',
+    }
 
 
 def test_init_func_fit_reports_wf_with_atlas_and_refmask(tmp_path: Path):


### PR DESCRIPTION
This PR addresses issue #272 by adding PVC metadata to the _tacs.json output file. This metadata is relevant to assess how the data were generated, which will vary depending on the method and choices, e.g. PSF. The metadata is aligned with the current PET-BIDS derivatives specification. 