### PR TITLE
Validate reference-mask and segmentation compatibility during CLI parsing

### DIFF
--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -813,9 +813,15 @@ discourage its usage.""",
 
 def parse_args(args=None, namespace=None):
     """Parse args and run further checks on the command line."""
+    from json import load
     import logging
 
     from niworkflows.utils.spaces import Reference, SpatialReferences
+
+    try:
+        from importlib.resources import files as ir_files
+    except ImportError:  # PY<3.9
+        from importlib_resources import files as ir_files
 
     argv = list(args) if args is not None else sys.argv[1:]
     parser = _build_parser()
@@ -863,6 +869,24 @@ def parse_args(args=None, namespace=None):
 
     if opts.ref_mask_index is not None and opts.ref_mask_name is None:
         parser.error('Option --ref-mask-index requires --ref-mask-name.')
+
+    if opts.ref_mask_name is not None and opts.ref_mask_index is None:
+        with open(ir_files('petprep.data.reference_mask') / 'config.json') as f:
+            refmask_config = load(f)
+
+        seg_refmask_config = refmask_config.get(config.workflow.seg, {})
+        if opts.ref_mask_name not in seg_refmask_config:
+            allowed_regions = sorted(seg_refmask_config.keys())
+            if allowed_regions:
+                parser.error(
+                    f"--ref-mask-name '{opts.ref_mask_name}' is not available for "
+                    f"--seg {config.workflow.seg}. Choose one of: {', '.join(allowed_regions)}."
+                )
+            parser.error(
+                f'--seg {config.workflow.seg} does not define any predefined reference masks. '
+                'Either select a compatible segmentation or provide --ref-mask-index '
+                'for custom labels.'
+            )
 
     if opts.ref_mask_name is not None:
         config.workflow.ref_mask_name = opts.ref_mask_name

--- a/petprep/cli/tests/test_parser.py
+++ b/petprep/cli/tests/test_parser.py
@@ -487,6 +487,16 @@ def test_reference_mask_options(tmp_path, minimal_bids, monkeypatch):
     assert config.workflow.ref_mask_index == (3, 4)
     _reset_config()
 
+    # Default segmentation is GTM; semiovale is only defined for WM segmentation
+    with pytest.raises(SystemExit):
+        parse_args(args=base_args + ['--ref-mask-name', 'semiovale'])
+    _reset_config()
+
+    parse_args(args=base_args + ['--seg', 'wm', '--ref-mask-name', 'semiovale'])
+    assert config.workflow.seg == 'wm'
+    assert config.workflow.ref_mask_name == 'semiovale'
+    _reset_config()
+
 
 def test_hmc_init_frame_parsing(tmp_path):
     """Ensure --hmc-init-frame accepts optional integers and defaults to auto."""


### PR DESCRIPTION
### Motivation
- Prevent long-running workflows from failing late due to an invalid combination of `--seg` and predefined `--ref-mask-name` (e.g., `semiovale` only exists for `--seg wm`).

### Description
- Add early validation in `parse_args` to load `petprep.data.reference_mask/config.json` and check that a provided `--ref-mask-name` is defined for the selected `config.workflow.seg` when `--ref-mask-index` is not supplied.
- Emit a clear `parser.error(...)` with actionable text when the chosen region is incompatible with the segmentation, or when the segmentation defines no predefined reference masks.
- Preserve existing behavior for custom masks specified via `--ref-mask-index` so users can still provide custom label indices.
- Extend `petprep/cli/tests/test_parser.py::test_reference_mask_options` with checks for the incompatible default (`gtm` + `semiovale`) and the compatible `--seg wm --ref-mask-name semiovale` case.

### Testing
- Ran `pytest -q -o addopts='' petprep/cli/tests/test_parser.py::test_reference_mask_options` and the test passed (`1 passed`).
- An initial attempt to run the same test without overriding `addopts` failed due to environment `pytest` addopts including coverage args not available in this runner (this is an environment issue, not a code failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e927c76b9c8330a3caed783279307b)