### PR TITLE
ENH: Add validation for segmentation and reference region

### DIFF
--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -813,8 +813,8 @@ discourage its usage.""",
 
 def parse_args(args=None, namespace=None):
     """Parse args and run further checks on the command line."""
-    from json import load
     import logging
+    from json import load
 
     from niworkflows.utils.spaces import Reference, SpatialReferences
 

--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -880,7 +880,7 @@ def parse_args(args=None, namespace=None):
             if allowed_regions:
                 parser.error(
                     f"--ref-mask-name '{opts.ref_mask_name}' is not available for "
-                    f"--seg {config.workflow.seg}. Choose one of: {', '.join(allowed_regions)}."
+                    f'--seg {config.workflow.seg}. Choose one of: {", ".join(allowed_regions)}.'
                 )
             parser.error(
                 f'--seg {config.workflow.seg} does not define any predefined reference masks. '

--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -876,11 +876,20 @@ def parse_args(args=None, namespace=None):
 
         seg_refmask_config = refmask_config.get(config.workflow.seg, {})
         if opts.ref_mask_name not in seg_refmask_config:
+            supported_segs = sorted(
+                seg_name
+                for seg_name, seg_config in refmask_config.items()
+                if opts.ref_mask_name in seg_config
+            )
             allowed_regions = sorted(seg_refmask_config.keys())
+            seg_hint = ''
+            if supported_segs:
+                seg_hint = f", but only for --seg {', '.join(supported_segs)}"
             if allowed_regions:
                 parser.error(
                     f"--ref-mask-name '{opts.ref_mask_name}' is not available for "
-                    f'--seg {config.workflow.seg}. Choose one of: {", ".join(allowed_regions)}.'
+                    f'--seg {config.workflow.seg}{seg_hint}. '
+                    f'Choose one of: {", ".join(allowed_regions)} for --seg {config.workflow.seg}.'
                 )
             parser.error(
                 f'--seg {config.workflow.seg} does not define any predefined reference masks. '

--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -813,9 +813,15 @@ discourage its usage.""",
 
 def parse_args(args=None, namespace=None):
     """Parse args and run further checks on the command line."""
+    from json import load
     import logging
 
     from niworkflows.utils.spaces import Reference, SpatialReferences
+
+    try:
+        from importlib.resources import files as ir_files
+    except ImportError:  # PY<3.9
+        from importlib_resources import files as ir_files
 
     argv = list(args) if args is not None else sys.argv[1:]
     parser = _build_parser()
@@ -863,6 +869,24 @@ def parse_args(args=None, namespace=None):
 
     if opts.ref_mask_index is not None and opts.ref_mask_name is None:
         parser.error('Option --ref-mask-index requires --ref-mask-name.')
+
+    if opts.ref_mask_name is not None and opts.ref_mask_index is None:
+        with open(ir_files('petprep.data.reference_mask') / 'config.json') as f:
+            refmask_config = load(f)
+
+        seg_refmask_config = refmask_config.get(config.workflow.seg, {})
+        if opts.ref_mask_name not in seg_refmask_config:
+            allowed_regions = sorted(seg_refmask_config.keys())
+            if allowed_regions:
+                parser.error(
+                    f"--ref-mask-name '{opts.ref_mask_name}' is not available for "
+                    f"--seg {config.workflow.seg}. Choose one of: {', '.join(allowed_regions)}."
+                )
+            parser.error(
+                f'--seg {config.workflow.seg} does not define any predefined reference masks. '
+                'Either select a compatible segmentation or provide --ref-mask-index '
+                'for custom labels.'
+            )
 
     if opts.ref_mask_name is not None:
         config.workflow.ref_mask_name = opts.ref_mask_name

--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -884,7 +884,7 @@ def parse_args(args=None, namespace=None):
             allowed_regions = sorted(seg_refmask_config.keys())
             seg_hint = ''
             if supported_segs:
-                seg_hint = f", but only for --seg {', '.join(supported_segs)}"
+                seg_hint = f', but only for --seg {", ".join(supported_segs)}'
             if allowed_regions:
                 parser.error(
                     f"--ref-mask-name '{opts.ref_mask_name}' is not available for "

--- a/petprep/cli/tests/test_parser.py
+++ b/petprep/cli/tests/test_parser.py
@@ -466,7 +466,7 @@ def test_pvc_invalid_method(tmp_path, minimal_bids):
     _reset_config()
 
 
-def test_reference_mask_options(tmp_path, minimal_bids, monkeypatch):
+def test_reference_mask_options(tmp_path, minimal_bids, monkeypatch, capsys):
     work_dir = tmp_path / 'work'
     base_args = [
         str(minimal_bids),
@@ -490,6 +490,11 @@ def test_reference_mask_options(tmp_path, minimal_bids, monkeypatch):
     # Default segmentation is GTM; semiovale is only defined for WM segmentation
     with pytest.raises(SystemExit):
         parse_args(args=base_args + ['--ref-mask-name', 'semiovale'])
+    err = capsys.readouterr().err
+    assert (
+        "--ref-mask-name 'semiovale' is not available for --seg gtm, but only for --seg wm. "
+        'Choose one of: cerebellum, neocortex, thalamus for --seg gtm.' in err
+    )
     _reset_config()
 
     parse_args(args=base_args + ['--seg', 'wm', '--ref-mask-name', 'semiovale'])

--- a/petprep/cli/tests/test_parser.py
+++ b/petprep/cli/tests/test_parser.py
@@ -503,6 +503,53 @@ def test_reference_mask_options(tmp_path, minimal_bids, monkeypatch, capsys):
     _reset_config()
 
 
+def test_reference_mask_validation_edge_cases(tmp_path, minimal_bids, monkeypatch, capsys):
+    """Cover parser errors for unsupported masks with and without segmentation mappings."""
+    from importlib import resources
+    from importlib.resources import files as ir_files
+
+    work_dir = tmp_path / 'work'
+    base_args = [
+        str(minimal_bids),
+        str(tmp_path / 'out'),
+        'participant',
+        '-w',
+        str(work_dir),
+        '--skip-bids-validation',
+    ]
+
+    # Force a ref-mask config where default GTM has known regions, but the queried
+    # mask is unavailable in every segmentation -> supported_segs is empty.
+    refmask_dir = tmp_path / 'fake_refmask'
+    refmask_dir.mkdir()
+    (refmask_dir / 'config.json').write_text(
+        '{"gtm": {"cerebellum": {"refmask_indices": [47, 8]}}, "wm": {"semiovale": {"refmask_indices": [5001, 5002]}}}'
+    )
+
+    def _mock_files(pkg_name):
+        if pkg_name == 'petprep.data.reference_mask':
+            return refmask_dir
+        return ir_files(pkg_name)
+
+    monkeypatch.setattr(resources, 'files', _mock_files)
+
+    with pytest.raises(SystemExit):
+        parse_args(args=base_args + ['--ref-mask-name', 'not-a-region'])
+    err = capsys.readouterr().err
+    assert (
+        "--ref-mask-name 'not-a-region' is not available for --seg gtm. "
+        'Choose one of: cerebellum for --seg gtm.' in err
+    )
+    _reset_config()
+
+    # Segmentation choices can include entries not present in refmask config.
+    with pytest.raises(SystemExit):
+        parse_args(args=base_args + ['--seg', 'brainstem', '--ref-mask-name', 'cerebellum'])
+    err = capsys.readouterr().err
+    assert '--seg brainstem does not define any predefined reference masks.' in err
+    _reset_config()
+
+
 def test_hmc_init_frame_parsing(tmp_path):
     """Ensure --hmc-init-frame accepts optional integers and defaults to auto."""
     datapath = tmp_path / 'data'

--- a/petprep/cli/tests/test_parser.py
+++ b/petprep/cli/tests/test_parser.py
@@ -487,6 +487,16 @@ def test_reference_mask_options(tmp_path, minimal_bids, monkeypatch):
     assert config.workflow.ref_mask_index == (3, 4)
     _reset_config()
 
+    # Default segmentation is GTM; semiovale is only defined for WM segmentation
+    with pytest.raises(SystemExit):
+        parse_args(args=base_args + ['--ref-mask-name', 'semiovale'])
+    _reset_config()
+
+    parse_args(args=base_args + ['--seg', 'wm', '--ref-mask-name', 'semiovale'])
+    assert config.workflow.seg == 'wm'
+    assert config.workflow.ref_mask_name == 'semiovale'
+    _reset_config()
+
 
 def test_hmc_init_frame_parsing(tmp_path):
     """Ensure --hmc-init-frame accepts optional integers and defaults to auto."""


### PR DESCRIPTION
This PR addresses issue #281, by implementing a check early on that if a given --ref-mask-name is chosen, then it should also align with the segmentation chosen. If not, it should stop the workflow, and require the user input to be changed. This will avoid this error happening at a very late stage (stage 4 of the PET workflow) of the workflow.