### PR TITLE
ENH: Fix reference mask resampling

### DIFF
--- a/petprep/interfaces/tests/test_tacs.py
+++ b/petprep/interfaces/tests/test_tacs.py
@@ -308,6 +308,43 @@ def test_ref_tacs_workflow_uses_input_pet_and_resampled_mask(tmp_path):
     assert inputs['in_file'] == str(pet_file)
     assert inputs['mask_file'].endswith('mask_resampled.nii.gz')
 
+    resampled_mask = nb.load(inputs['mask_file'])
+    assert np.array_equal(
+        np.rint(resampled_mask.get_fdata()).astype(np.int16),
+        mask_data,
+    )
+
+
+def test_ref_tacs_workflow_3d_pet(tmp_path):
+    """Workflow should support single-frame (3D) PET images."""
+    pet_data = np.ones((2, 2, 2), dtype=np.float32)
+    pet_file = tmp_path / 'pet3d.nii.gz'
+    nb.Nifti1Image(pet_data, np.eye(4)).to_filename(pet_file)
+
+    mask_data = np.zeros((2, 2, 2), dtype='int16')
+    mask_data[0] = 1
+    mask_file = tmp_path / 'mask.nii.gz'
+    nb.Nifti1Image(mask_data, np.eye(4)).to_filename(mask_file)
+
+    meta_json = tmp_path / 'pet3d.json'
+    meta_json.write_text(json.dumps({'FrameTimesStart': [0], 'FrameDuration': [1]}))
+
+    wf = init_pet_ref_tacs_wf()
+    wf.base_dir = str(tmp_path)
+    wf.config['execution']['remove_unnecessary_outputs'] = False
+    wf.inputs.inputnode.pet_anat = str(pet_file)
+    wf.inputs.inputnode.mask_file = str(mask_file)
+    wf.inputs.inputnode.metadata = str(meta_json)
+    wf.inputs.inputnode.ref_mask_name = 'ref'
+
+    wf.run()
+
+    out_tsv = tmp_path / 'pet_ref_tacs_wf' / 'tac' / 'pet3d_tacs.tsv'
+    assert out_tsv.exists()
+    out = pd.read_csv(out_tsv, sep='	')
+    assert list(out.columns) == ['frame_start', 'frame_end', 'ref']
+    assert out.shape[0] == 1
+
 
 def test_ref_tacs_workflow_nonoverlapping_affines(tmp_path):
     """Workflow should not crash when PET and mask FoVs do not overlap."""

--- a/petprep/interfaces/tests/test_tacs.py
+++ b/petprep/interfaces/tests/test_tacs.py
@@ -11,7 +11,7 @@ from nipype.pipeline import engine as pe
 from nipype.pipeline.engine.nodes import NodeExecutionError
 
 from petprep.interfaces.tacs import ExtractRefTAC, ExtractTACs
-from petprep.workflows.pet.ref_tacs import init_pet_ref_tacs_wf
+from petprep.workflows.pet.ref_tacs import init_pet_ref_tacs_wf, resample_mask_to_pet
 from petprep.workflows.pet.tacs import init_pet_tacs_wf
 
 
@@ -414,7 +414,7 @@ def test_ref_tacs_workflow_mismatched_meta(tmp_path):
         wf.run()
 
 
-def test_resample_pet_to_mask_fallback(tmp_path, monkeypatch):
+def test_resample_mask_to_pet_fallback(tmp_path, monkeypatch):
     """Fallback resampling should run when nilearn raises BoundingBoxError."""
     pet_data = np.stack([np.ones((2, 2, 2)), np.ones((2, 2, 2)) * 2], axis=-1)
     pet_file = tmp_path / 'pet.nii.gz'
@@ -431,6 +431,6 @@ def test_resample_pet_to_mask_fallback(tmp_path, monkeypatch):
 
     monkeypatch.setattr('nilearn.image.resample_to_img', _raise_bbox_error)
 
-    out_file = resample_pet_to_mask(str(pet_file), str(mask_file))
+    out_file = resample_mask_to_pet(str(mask_file), str(pet_file))
     out_img = nb.load(out_file)
-    assert out_img.shape == (2, 2, 2, 2)
+    assert out_img.shape == (2, 2, 2)

--- a/petprep/interfaces/tests/test_tacs.py
+++ b/petprep/interfaces/tests/test_tacs.py
@@ -271,6 +271,80 @@ def test_ExtractRefTAC_mismatched_frames(tmp_path):
         node.run()
 
 
+def test_ref_tacs_workflow_uses_input_pet_and_resampled_mask(tmp_path):
+    """Workflow should preserve PET input and only resample the reference mask."""
+    pet_data = np.stack(
+        [
+            np.ones((2, 2, 2)),
+            np.ones((2, 2, 2)) * 2,
+        ],
+        axis=-1,
+    )
+    pet_file = tmp_path / 'pet.nii.gz'
+    nb.Nifti1Image(pet_data, np.eye(4)).to_filename(pet_file)
+
+    mask_data = np.zeros((2, 2, 2), dtype='int16')
+    mask_data[0] = 1
+    mask_file = tmp_path / 'mask.nii.gz'
+    nb.Nifti1Image(mask_data, np.eye(4)).to_filename(mask_file)
+
+    meta_json = tmp_path / 'pet.json'
+    meta_json.write_text(json.dumps({'FrameTimesStart': [0, 1], 'FrameDuration': [1, 1]}))
+
+    wf = init_pet_ref_tacs_wf()
+    wf.base_dir = str(tmp_path)
+    wf.config['execution']['remove_unnecessary_outputs'] = False
+    wf.inputs.inputnode.pet_anat = str(pet_file)
+    wf.inputs.inputnode.mask_file = str(mask_file)
+    wf.inputs.inputnode.metadata = str(meta_json)
+    wf.inputs.inputnode.ref_mask_name = 'ref'
+
+    wf.run()
+
+    tac_inputs_file = tmp_path / 'pet_ref_tacs_wf' / 'tac' / '_inputs.pklz'
+    with gzip.open(tac_inputs_file, 'rb') as f:
+        inputs = pickle.load(f)
+
+    assert inputs['in_file'] == str(pet_file)
+    assert inputs['mask_file'].endswith('mask_resampled.nii.gz')
+
+
+def test_ref_tacs_workflow_nonoverlapping_affines(tmp_path):
+    """Workflow should not crash when PET and mask FoVs do not overlap."""
+    pet_data = np.stack(
+        [
+            np.ones((2, 2, 2)),
+            np.ones((2, 2, 2)) * 2,
+        ],
+        axis=-1,
+    )
+    pet_file = tmp_path / 'pet.nii.gz'
+    nb.Nifti1Image(pet_data, np.eye(4)).to_filename(pet_file)
+
+    mask_data = np.zeros((2, 2, 2), dtype='int16')
+    mask_data[0] = 1
+    mask_file = tmp_path / 'mask_shifted.nii.gz'
+    shifted_affine = np.eye(4)
+    shifted_affine[:3, 3] = 1000
+    nb.Nifti1Image(mask_data, shifted_affine).to_filename(mask_file)
+
+    meta_json = tmp_path / 'pet.json'
+    meta_json.write_text(json.dumps({'FrameTimesStart': [0, 1], 'FrameDuration': [1, 1]}))
+
+    wf = init_pet_ref_tacs_wf()
+    wf.base_dir = str(tmp_path)
+    wf.config['execution']['remove_unnecessary_outputs'] = False
+    wf.inputs.inputnode.pet_anat = str(pet_file)
+    wf.inputs.inputnode.mask_file = str(mask_file)
+    wf.inputs.inputnode.metadata = str(meta_json)
+    wf.inputs.inputnode.ref_mask_name = 'ref'
+
+    wf.run()
+
+    out_tsv = tmp_path / 'pet_ref_tacs_wf' / 'tac' / 'pet_tacs.tsv'
+    assert out_tsv.exists()
+
+
 def test_ref_tacs_workflow_mismatched_meta(tmp_path):
     """Workflow should fail with inconsistent metadata."""
     pet_data = np.stack(

--- a/petprep/interfaces/tests/test_tacs.py
+++ b/petprep/interfaces/tests/test_tacs.py
@@ -301,3 +301,25 @@ def test_ref_tacs_workflow_mismatched_meta(tmp_path):
 
     with pytest.raises(NodeExecutionError):
         wf.run()
+
+
+def test_resample_pet_to_mask_fallback(tmp_path, monkeypatch):
+    """Fallback resampling should run when nilearn raises BoundingBoxError."""
+    pet_data = np.stack([np.ones((2, 2, 2)), np.ones((2, 2, 2)) * 2], axis=-1)
+    pet_file = tmp_path / 'pet.nii.gz'
+    nb.Nifti1Image(pet_data, np.eye(4)).to_filename(pet_file)
+
+    mask_data = np.ones((2, 2, 2), dtype='int16')
+    mask_file = tmp_path / 'mask.nii.gz'
+    nb.Nifti1Image(mask_data, np.eye(4)).to_filename(mask_file)
+
+    from nilearn.image.resampling import BoundingBoxError
+
+    def _raise_bbox_error(*args, **kwargs):
+        raise BoundingBoxError('synthetic failure')
+
+    monkeypatch.setattr('nilearn.image.resample_to_img', _raise_bbox_error)
+
+    out_file = resample_pet_to_mask(str(pet_file), str(mask_file))
+    out_img = nb.load(out_file)
+    assert out_img.shape == (2, 2, 2, 2)

--- a/petprep/workflows/pet/ref_tacs.py
+++ b/petprep/workflows/pet/ref_tacs.py
@@ -18,7 +18,9 @@ def resample_mask_to_pet(mask_file, pet_file):
     pet_img = nb.load(pet_file)
     mask_img = nb.load(mask_file)
 
-    same_grid = mask_img.shape[:3] == pet_img.shape[:3] and np.allclose(mask_img.affine, pet_img.affine)
+    same_grid = mask_img.shape[:3] == pet_img.shape[:3] and np.allclose(
+        mask_img.affine, pet_img.affine
+    )
 
     if same_grid:
         resampled = mask_img

--- a/petprep/workflows/pet/ref_tacs.py
+++ b/petprep/workflows/pet/ref_tacs.py
@@ -18,26 +18,31 @@ def resample_mask_to_pet(mask_file, pet_file):
     pet_img = nb.load(pet_file)
     mask_img = nb.load(mask_file)
 
-    try:
-        resampled = resample_to_img(
-            mask_file,
-            pet_file,
-            interpolation='nearest',
-            copy_header=True,
-        )
-    except BoundingBoxError:
+    same_grid = mask_img.shape[:3] == pet_img.shape[:3] and np.allclose(mask_img.affine, pet_img.affine)
+
+    if same_grid:
+        resampled = mask_img
+    else:
         try:
-            resampled = resample_img(
-                mask_img,
-                target_affine=pet_img.affine,
-                target_shape=pet_img.shape[:3],
+            resampled = resample_to_img(
+                mask_file,
+                pet_file,
                 interpolation='nearest',
-                force_resample=True,
                 copy_header=True,
             )
         except BoundingBoxError:
-            zeros = np.zeros(pet_img.shape[:3], dtype=np.int16)
-            resampled = nb.Nifti1Image(zeros, pet_img.affine, pet_img.header)
+            try:
+                resampled = resample_img(
+                    mask_img,
+                    target_affine=pet_img.affine,
+                    target_shape=pet_img.shape[:3],
+                    interpolation='nearest',
+                    force_resample=True,
+                    copy_header=True,
+                )
+            except BoundingBoxError:
+                zeros = np.zeros(pet_img.shape[:3], dtype=np.int16)
+                resampled = nb.Nifti1Image(zeros, pet_img.affine, pet_img.header)
 
     out_data = np.rint(resampled.get_fdata()).astype(np.int16)
     out_file = os.path.abspath('mask_resampled.nii.gz')

--- a/petprep/workflows/pet/ref_tacs.py
+++ b/petprep/workflows/pet/ref_tacs.py
@@ -10,9 +10,45 @@ from ...interfaces import ExtractRefTAC
 def resample_pet_to_mask(pet_file, mask_file):
     import os
 
+    import nibabel as nb
+    import numpy as np
     from nilearn.image import resample_to_img
+    from nilearn.image.resampling import BoundingBoxError
 
-    resampled = resample_to_img(pet_file, mask_file, interpolation='continuous')
+    pet_img = nb.load(pet_file)
+    mask_img = nb.load(mask_file)
+
+    try:
+        resampled = resample_to_img(pet_img, mask_img, interpolation='continuous')
+    except BoundingBoxError:
+        from nibabel.processing import resample_from_to
+
+        # Fallback to nibabel resampling, which is more permissive when
+        # world-space bounding boxes are numerically inconsistent.
+        if pet_img.ndim == 3:
+            resampled = resample_from_to(pet_img, mask_img, order=1, mode='constant', cval=0.0)
+        else:
+            frame_data = []
+            for frame_idx in range(pet_img.shape[-1]):
+                frame_img = nb.Nifti1Image(
+                    pet_img.dataobj[..., frame_idx],
+                    pet_img.affine,
+                    pet_img.header,
+                )
+                resampled_frame = resample_from_to(
+                    frame_img,
+                    mask_img,
+                    order=1,
+                    mode='constant',
+                    cval=0.0,
+                )
+                frame_data.append(resampled_frame.get_fdata())
+            resampled = nb.Nifti1Image(
+                np.asarray(np.stack(frame_data, axis=-1), dtype=np.float32),
+                mask_img.affine,
+                mask_img.header,
+            )
+
     out_file = os.path.abspath('pet_resampled.nii.gz')
     resampled.to_filename(out_file)
     return out_file

--- a/petprep/workflows/pet/ref_tacs.py
+++ b/petprep/workflows/pet/ref_tacs.py
@@ -7,50 +7,41 @@ from nipype.pipeline import engine as pe
 from ...interfaces import ExtractRefTAC
 
 
-def resample_pet_to_mask(pet_file, mask_file):
+def resample_mask_to_pet(mask_file, pet_file):
     import os
 
     import nibabel as nb
     import numpy as np
-    from nilearn.image import resample_to_img
+    from nilearn.image import resample_img, resample_to_img
     from nilearn.image.resampling import BoundingBoxError
 
     pet_img = nb.load(pet_file)
     mask_img = nb.load(mask_file)
 
     try:
-        resampled = resample_to_img(pet_img, mask_img, interpolation='continuous')
+        resampled = resample_to_img(
+            mask_file,
+            pet_file,
+            interpolation='nearest',
+            copy_header=True,
+        )
     except BoundingBoxError:
-        from nibabel.processing import resample_from_to
-
-        # Fallback to nibabel resampling, which is more permissive when
-        # world-space bounding boxes are numerically inconsistent.
-        if pet_img.ndim == 3:
-            resampled = resample_from_to(pet_img, mask_img, order=1, mode='constant', cval=0.0)
-        else:
-            frame_data = []
-            for frame_idx in range(pet_img.shape[-1]):
-                frame_img = nb.Nifti1Image(
-                    pet_img.dataobj[..., frame_idx],
-                    pet_img.affine,
-                    pet_img.header,
-                )
-                resampled_frame = resample_from_to(
-                    frame_img,
-                    mask_img,
-                    order=1,
-                    mode='constant',
-                    cval=0.0,
-                )
-                frame_data.append(resampled_frame.get_fdata())
-            resampled = nb.Nifti1Image(
-                np.asarray(np.stack(frame_data, axis=-1), dtype=np.float32),
-                mask_img.affine,
-                mask_img.header,
+        try:
+            resampled = resample_img(
+                mask_img,
+                target_affine=pet_img.affine,
+                target_shape=pet_img.shape[:3],
+                interpolation='nearest',
+                force_resample=True,
+                copy_header=True,
             )
+        except BoundingBoxError:
+            zeros = np.zeros(pet_img.shape[:3], dtype=np.int16)
+            resampled = nb.Nifti1Image(zeros, pet_img.affine, pet_img.header)
 
-    out_file = os.path.abspath('pet_resampled.nii.gz')
-    resampled.to_filename(out_file)
+    out_data = np.rint(resampled.get_fdata()).astype(np.int16)
+    out_file = os.path.abspath('mask_resampled.nii.gz')
+    nb.Nifti1Image(out_data, pet_img.affine, pet_img.header).to_filename(out_file)
     return out_file
 
 
@@ -65,13 +56,13 @@ def init_pet_ref_tacs_wf(*, name: str = 'pet_ref_tacs_wf') -> pe.Workflow:
     )
     outputnode = pe.Node(niu.IdentityInterface(fields=['timeseries']), name='outputnode')
 
-    resample_pet = pe.Node(
+    resample_mask = pe.Node(
         Function(
-            input_names=['pet_file', 'mask_file'],
-            output_names=['resampled_pet'],
-            function=resample_pet_to_mask,
+            input_names=['mask_file', 'pet_file'],
+            output_names=['resampled_mask'],
+            function=resample_mask_to_pet,
         ),
-        name='resample_pet',
+        name='resample_mask',
     )
 
     tac = pe.Node(ExtractRefTAC(), name='tac')
@@ -80,15 +71,15 @@ def init_pet_ref_tacs_wf(*, name: str = 'pet_ref_tacs_wf') -> pe.Workflow:
         [
             (
                 inputnode,
-                resample_pet,
+                resample_mask,
                 [('pet_anat', 'pet_file'), ('mask_file', 'mask_file')],
             ),
-            (resample_pet, tac, [('resampled_pet', 'in_file')]),
+            (inputnode, tac, [('pet_anat', 'in_file')]),
+            (resample_mask, tac, [('resampled_mask', 'mask_file')]),
             (
                 inputnode,
                 tac,
                 [
-                    ('mask_file', 'mask_file'),
                     ('metadata', 'metadata'),
                     ('ref_mask_name', 'ref_mask_name'),
                 ],


### PR DESCRIPTION
This PR addresses issue #240 by updating the resample_pet_to_ref workflow, and handle nilearn related issues related to the affines. The input to the workflow is already the resampled PET data to the anatomical, and since the mask is generated from the anatomical data, these should already be aligned and have the same 3D dimensions. 