### PR TITLE
Add citation-aware PET boilerplate builders and bibliography entries

### DIFF
--- a/petprep/data/boilerplate.bib
+++ b/petprep/data/boilerplate.bib
@@ -376,3 +376,48 @@
     pages = {1402--1418},
     year = {2012}
 }
+
+@article{petpvc,
+    author = {Thomas, Benjamin A. and Cuplov, Vesna and Bousse, Alexandre and Mendes, Anna and Thielemans, Kris and Hutton, Brian F. and Erlandsson, Kjell},
+    title = {PETPVC: A toolbox for performing partial volume correction techniques in positron emission tomography},
+    journal = {Physics in Medicine and Biology},
+    volume = {61},
+    number = {22},
+    pages = {7975--7993},
+    year = {2016},
+    doi = {10.1088/0031-9155/61/22/7975}
+}
+
+@article{petsurfer,
+    author = {Greve, Douglas N. and Svarer, Claus and Fisher, Patrick M. and Feng, Lei and Hansen, Adam E. and Baare, William and Rosen, Bruce and Fischl, Bruce and Knudsen, Gitte M.},
+    title = {Cortical surface-based analysis reduces bias and variance in kinetic modeling of brain PET data},
+    journal = {NeuroImage},
+    volume = {92},
+    pages = {225--236},
+    year = {2014},
+    doi = {10.1016/j.neuroimage.2013.12.021}
+}
+
+@article{massp20,
+    author = {Bazin, Pierre-Louis and Groot, Judith M. and Miletic, Sanja and Groenewegen, Lieske and Trutti, Ann-Christin and Mulder, Mark J. and Forstmann, Birte U. and Alkemade, Anne},
+    title = {Automated parcellation and atlasing of the human subcortex with ultra-high resolution quantitative MRI},
+    journal = {Imaging Neuroscience},
+    volume = {3},
+    pages = {imag_a_00560},
+    year = {2025},
+    doi = {10.1162/imag_a_00560}
+}
+
+@misc{schaefer2018,
+    author = {Schaefer, Alexander and Kong, Ru and Gordon, Evan M. and Laumann, Timothy O. and Zuo, Xi-Nian and Holmes, Avram J. and Eickhoff, Simon B. and Yeo, B. T. Thomas},
+    title = {Local-Global Parcellation of the Human Cerebral Cortex from Intrinsic Functional Connectivity MRI},
+    year = {2018},
+    doi = {10.1093/cercor/bhx179}
+}
+
+@misc{hocpa,
+    title = {Harvard-Oxford cortical and subcortical atlas},
+    howpublished = {\url{https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Atlases}},
+    note = {FMRIB Software Library (FSL)},
+    year = {2006}
+}

--- a/petprep/workflows/base.py
+++ b/petprep/workflows/base.py
@@ -43,6 +43,54 @@ from ..interfaces import DerivativesDataSink
 from ..interfaces.reports import AboutSummary, SubjectSummary
 
 
+def _build_segmentation_boilerplate(seg: str) -> str:
+    """Compose segmentation boilerplate text for the selected workflow."""
+    from ..utils.atlas import load_atlas_config
+
+    atlas_config = load_atlas_config()
+    atlas_citations = {
+        'MASSP20': ' [@massp20].',
+        'HOCPA': ' [@hocpa].',
+    }
+
+    if seg in atlas_config:
+        citation = atlas_citations.get(seg, ' [@schaefer2018].' if seg.startswith('Schaefer2018') else '.')
+        return (
+            f'A brain mask was computed and the structural image was segmented with the '
+            f'``{seg}`` atlas, which was warped into anatomical space{citation}'
+        )
+
+    return (
+        f'A brain mask was computed and the structural image was segmented using the '
+        f'``{seg}`` FreeSurfer workflow [@fs_reconall].'
+    )
+
+
+def _build_pvc_boilerplate(pvc_tool: str, pvc_method: str, pvc_psf: tuple[float, ...]) -> str:
+    """Compose PVC boilerplate text including tool references."""
+    pvc_citation = {'petpvc': '[@petpvc]', 'petsurfer': '[@petsurfer]'}.get(pvc_tool.lower())
+    citation_text = f' {pvc_citation}' if pvc_citation else ''
+    return (
+        f' Partial volume correction was applied using ``{pvc_tool}`` '
+        f'with method ``{pvc_method}`` and PSF {pvc_psf} mm{citation_text}.'
+    )
+
+
+def _build_reference_mask_boilerplate(ref_mask_name: str, ref_mask_index: tuple[int, ...] | None) -> str:
+    """Compose reference-mask boilerplate text."""
+    if ref_mask_index:
+        return (
+            f' A reference region mask for ``{ref_mask_name}`` was generated using '
+            f'segmentation labels {ref_mask_index}, and the corresponding time-activity '
+            'curve was extracted.'
+        )
+
+    return (
+        f' A predefined reference region mask for ``{ref_mask_name}`` was generated, '
+        'and the corresponding time-activity curve was extracted.'
+    )
+
+
 def init_petprep_wf():
     """
     Build *PETPrep*'s pipeline.
@@ -560,24 +608,18 @@ PET data preprocessing
 
 : For each of the {len(pet_runs)} PET runs found per subject (across all
 tasks and sessions), the following preprocessing steps were performed. Robust head
-motion estimation and correction were carried out after generating a
-reference image, which was subsequently coregistered to the T1-weighted
-anatomical image. A brain mask was computed and the structural image was
-segmented with the ``{config.workflow.seg}`` segmentation workflow from FreeSurfer."""
+motion estimation and correction were {'' if not config.workflow.hmc_off else 'not '}carried out after generating a
+reference image{'' if not config.workflow.hmc_off else ' from the uncorrected PET series'}, which was subsequently coregistered to the T1-weighted
+anatomical image. {_build_segmentation_boilerplate(config.workflow.seg)}"""
 
     if config.workflow.pvc_tool and config.workflow.pvc_method:
-        pet_pre_desc += (
-            f' Partial volume correction was applied using'
-            f' ``{config.workflow.pvc_tool}`` using the method'
-            f' ``{config.workflow.pvc_method}`` and with a PSF of'
-            f' {config.workflow.pvc_psf} mm.'
+        pet_pre_desc += _build_pvc_boilerplate(
+            config.workflow.pvc_tool, config.workflow.pvc_method, config.workflow.pvc_psf
         )
 
     if config.workflow.ref_mask_name:
-        pet_pre_desc += (
-            f' A reference region mask for the ``{config.workflow.ref_mask_name}``'
-            ' was generated and the corresponding time-activity curve'
-            ' extracted.'
+        pet_pre_desc += _build_reference_mask_boilerplate(
+            config.workflow.ref_mask_name, config.workflow.ref_mask_index
         )
 
     pet_pre_desc += '\n'

--- a/petprep/workflows/tests/test_base.py
+++ b/petprep/workflows/tests/test_base.py
@@ -13,7 +13,13 @@ from niworkflows.utils.bids import collect_data as original_collect_data
 from niworkflows.utils.testing import generate_bids_skeleton
 
 from ... import config
-from ..base import init_petprep_wf, init_single_subject_wf
+from ..base import (
+    _build_pvc_boilerplate,
+    _build_reference_mask_boilerplate,
+    _build_segmentation_boilerplate,
+    init_petprep_wf,
+    init_single_subject_wf,
+)
 from ..tests import mock_config
 
 BASE_LAYOUT = {
@@ -127,6 +133,32 @@ def test_segmentation_shared_across_runs(multisession_bids_root):
         assert ('outputnode.segmentation', 'inputnode.segmentation') in edge['connect']
         assert ('outputnode.dseg_tsv', 'inputnode.dseg_tsv') in edge['connect']
         assert all('_seg_wf' not in n for n in pet_node.list_node_names())
+
+
+def test_segmentation_boilerplate_mentions_atlas_reference():
+    desc = _build_segmentation_boilerplate('MASSP20')
+    assert 'atlas' in desc
+    assert 'warped into anatomical space' in desc
+    assert '[@massp20]' in desc
+
+
+def test_pvc_boilerplate_includes_tool_reference():
+    desc = _build_pvc_boilerplate('petpvc', 'GTM', (5.0,))
+    assert '``petpvc``' in desc
+    assert '``GTM``' in desc
+    assert '[@petpvc]' in desc
+
+
+def test_reference_mask_boilerplate_predefined():
+    desc = _build_reference_mask_boilerplate('cerebellum', None)
+    assert 'predefined reference region mask' in desc
+    assert '``cerebellum``' in desc
+
+
+def test_reference_mask_boilerplate_custom_labels():
+    desc = _build_reference_mask_boilerplate('custom', (8, 47))
+    assert 'segmentation labels (8, 47)' in desc
+    assert 'time-activity curve was extracted' in desc
 
 
 def _make_params(


### PR DESCRIPTION
### Motivation
- Improve the descriptive provenance text produced by the PETPrep workflow so it can reference the correct atlas and PVC tool citations and reflect whether head-motion correction was applied.
- Centralize and parameterize boilerplate composition for segmentation, partial-volume correction (PVC), and reference-mask descriptions to make the main workflow clearer and easier to test.

### Description
- Added three helper functions in `petprep/workflows/base.py`: `_build_segmentation_boilerplate`, `_build_pvc_boilerplate`, and `_build_reference_mask_boilerplate` to compose citation-aware description fragments for segmentation, PVC, and reference masks respectively.
- Refactored the PET preprocessing description in `init_petprep_wf` to use the new helpers and to include `hmc_off` logic when describing motion correction.
- Extended `petprep/data/boilerplate.bib` with new bibliography entries: `petpvc`, `petsurfer`, `massp20`, `schaefer2018`, and `hocpa` to support the generated citations.
- Updated `petprep/workflows/tests/test_base.py` to import and exercise the new helper functions and added unit tests checking the generated boilerplate content.

### Testing
- Ran the workflow unit tests in `petprep/workflows/tests/test_base.py` (including the new tests for `_build_segmentation_boilerplate`, `_build_pvc_boilerplate`, and `_build_reference_mask_boilerplate`) using `pytest`; all tests passed.
- Executed the expanded graph generation for the single-subject workflow via the existing tests to ensure no regressions in workflow wiring, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea194f0c5c8330b05585205f725c1a)