### PR TITLE
Add optional HMC blocking time and improve HMC frame selection/padding

### DIFF
--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -598,6 +598,16 @@ https://petprep.readthedocs.io/en/{currentv.base_version if is_release else 'lat
         help='Time (in seconds) after which head-motion estimation is performed.',
     )
     g_hmc.add_argument(
+        '--hmc-blocking-time',
+        action='store',
+        default=None,
+        type=float,
+        help=(
+            'Optional time (in seconds) when a blocking challenge starts. '
+            'Frames at or after this time are excluded from head-motion estimation.'
+        ),
+    )
+    g_hmc.add_argument(
         '--hmc-init-frame',
         dest='hmc_init_frame',
         nargs='?',

--- a/petprep/cli/tests/test_parser.py
+++ b/petprep/cli/tests/test_parser.py
@@ -584,3 +584,19 @@ def test_hmc_off_flag(tmp_path):
 
     opts = parser.parse_args(base_args + ['--hmc-off'])
     assert opts.hmc_off is True
+
+
+def test_hmc_blocking_time_parsing(tmp_path):
+    """Ensure --hmc-blocking-time is optional and parsed as float."""
+    datapath = tmp_path / 'data'
+    outpath = tmp_path / 'out'
+    datapath.mkdir()
+
+    parser = _build_parser()
+    base_args = [str(datapath), str(outpath), 'participant']
+
+    opts = parser.parse_args(base_args)
+    assert opts.hmc_blocking_time is None
+
+    opts = parser.parse_args(base_args + ['--hmc-blocking-time', '900'])
+    assert opts.hmc_blocking_time == 900.0

--- a/petprep/config.py
+++ b/petprep/config.py
@@ -616,6 +616,8 @@ class workflow(_Config):
     """FWHM for Gaussian smoothing prior to head-motion estimation."""
     hmc_start_time: float = 120.0
     """Time point (in seconds) at which head-motion estimation starts."""
+    hmc_blocking_time: float | None = None
+    """Optional blocking onset (seconds) to stop motion estimation before kinetic shifts."""
     hmc_init_frame: int | str | None = 'auto'
     """Index of initial frame for head-motion estimation ('auto' selects highest uptake)."""
     hmc_fix_frame: bool = False

--- a/petprep/workflows/pet/fit.py
+++ b/petprep/workflows/pet/fit.py
@@ -778,6 +778,7 @@ def init_pet_fit_wf(
             omp_nthreads=omp_nthreads,
             fwhm=config.workflow.hmc_fwhm,
             start_time=config.workflow.hmc_start_time,
+            blocking_time=config.workflow.hmc_blocking_time,
             frame_durations=frame_durations,
             frame_start_times=frame_start_times,
             initial_frame=config.workflow.hmc_init_frame,

--- a/petprep/workflows/pet/hmc.py
+++ b/petprep/workflows/pet/hmc.py
@@ -84,14 +84,23 @@ def get_start_frame(
     return int(idxs[0]) if idxs.size > 0 else int(len(midpoints) - 1)
 
 
-def update_list_transforms(xforms: list[str], idx: int) -> list[str]:
+def update_list_transforms(xforms: list[str], idx: int, total_frames: int) -> list[str]:
     """
-    Left-pad `xforms` by repeating the first transform `idx` times at the beginning.
+    Expand a partial transform list to cover all original frames.
+
+    The first transform is repeated to fill frames skipped at the beginning
+    (before ``idx``), and the last transform is repeated for any dropped tail
+    frames when only a subset of the scan is used for motion estimation.
     """
     if not xforms:
         raise ValueError('The input xforms list cannot be empty.')
 
     padded_xforms = [xforms[0]] * idx + xforms
+    if len(padded_xforms) < total_frames:
+        padded_xforms.extend([padded_xforms[-1]] * (total_frames - len(padded_xforms)))
+    elif len(padded_xforms) > total_frames:
+        padded_xforms = padded_xforms[:total_frames]
+
     return padded_xforms
 
 
@@ -106,6 +115,21 @@ def _find_highest_uptake_frame(in_files: list[str]) -> int:
 
     uptake = [np.sum(nb.load(f).get_fdata(dtype=np.float32)) for f in in_files]
     return int(np.argmax(uptake)) + 1
+
+
+def _select_estimation_indices(total_frames: int, start_idx: int, stop_idx: int | None = None) -> list[int]:
+    """Select frame indices used during motion estimation."""
+    total_frames = int(total_frames)
+    if total_frames <= 0:
+        return []
+
+    start_idx = max(0, min(int(start_idx), total_frames - 1))
+    if stop_idx is None:
+        stop_idx = total_frames
+    else:
+        stop_idx = max(start_idx + 1, min(int(stop_idx), total_frames))
+
+    return list(range(start_idx, stop_idx))
 
 
 class _LTAList2ITKInputSpec(BaseInterfaceInputSpec):
@@ -145,6 +169,7 @@ def init_pet_hmc_wf(
     *,
     fwhm: float = 10.0,
     start_time: float = 120.0,
+    blocking_time: float | None = None,
     frame_durations: Sequence[float] | None = None,
     frame_start_times: Sequence[float] | None = None,
     initial_frame: int | str | None = 'auto',
@@ -181,6 +206,10 @@ def init_pet_hmc_wf(
         FWHM in millimeters for Gaussian smoothing prior to motion estimation
     start_time : :obj:`float`
         Earliest time point (in seconds) used for motion estimation.
+    blocking_time : :obj:`float` or ``None``
+        Optional time point (in seconds) at which a blocking challenge starts.
+        When set, frames at or after this time are excluded from motion
+        estimation to avoid conflating tracer-kinetic changes with motion.
     frame_durations : :class:`~typing.Sequence`\[:obj:`float`] or ``None``
         Duration of each frame in seconds. If not provided, start-time clamping
         will be skipped.
@@ -228,11 +257,12 @@ FreeSurfer's ``mri_robust_template``.
 
     inputnode = pe.Node(
         niu.IdentityInterface(
-            fields=['pet_file', 'start_time', 'frame_durations', 'frame_start_times']
+            fields=['pet_file', 'start_time', 'blocking_time', 'frame_durations', 'frame_start_times']
         ),
         name='inputnode',
     )
     inputnode.inputs.start_time = start_time
+    inputnode.inputs.blocking_time = blocking_time
     inputnode.inputs.frame_durations = frame_durations
     inputnode.inputs.frame_start_times = frame_start_times
     outputnode = pe.Node(niu.IdentityInterface(fields=['xforms', 'petref']), name='outputnode')
@@ -242,10 +272,6 @@ FreeSurfer's ``mri_robust_template``.
 
     # After splitting, explicitly select frames
     select_frames = pe.Node(Select(), name='select_frames')
-
-    # Define a function to create the correct indices
-    def get_frame_indices(total_frames, start_idx):
-        return list(range(start_idx, total_frames))
 
     # Explicit function for Nipype connection
     def num_files(filelist):
@@ -258,12 +284,13 @@ FreeSurfer's ``mri_robust_template``.
 
     select_idx = pe.Node(
         niu.Function(
-            input_names=['total_frames', 'start_idx'],
+            input_names=['total_frames', 'start_idx', 'stop_idx'],
             output_names=['indices'],
-            function=get_frame_indices,
+            function=_select_estimation_indices,
         ),
         name='select_indices',
     )
+    select_idx.inputs.stop_idx = None
 
     # Smooth and threshold frames
     smooth = pe.MapNode(
@@ -285,6 +312,16 @@ FreeSurfer's ``mri_robust_template``.
         name='get_start_frame',
     )
     start_frame.inputs.start_time = start_time
+    if blocking_time is not None:
+        stop_frame = pe.Node(
+            niu.Function(
+                input_names=['durations', 'start_time', 'frame_starts'],
+                output_names=['start_frame_idx'],
+                function=get_start_frame,
+            ),
+            name='get_blocking_frame',
+        )
+        stop_frame.inputs.start_time = blocking_time
 
     make_lta_list = pe.Node(
         niu.Function(
@@ -323,7 +360,7 @@ FreeSurfer's ``mri_robust_template``.
         robust_template.inputs.initial_timepoint = int(initial_frame) + 1
     upd_xfm = pe.Node(
         niu.Function(
-            input_names=['xforms', 'idx'],
+            input_names=['xforms', 'idx', 'total_frames'],
             output_names=['updated_xforms'],
             function=update_list_transforms,
         ),
@@ -352,6 +389,7 @@ FreeSurfer's ``mri_robust_template``.
         (thresh, robust_template, [('out_file', 'in_files')]),
         (robust_template, upd_xfm, [('transform_outputs', 'xforms')]),
         (start_frame, upd_xfm, [('start_frame_idx', 'idx')]),
+        (num_files_node, upd_xfm, [('length', 'total_frames')]),
         (upd_xfm, lta2itk, [('updated_xforms', 'in_xforms')]),
         (robust_template, lta2itk, [('out_file', 'in_reference')]),
         (split, lta2itk, [('out_file', 'in_source')]),
@@ -359,6 +397,16 @@ FreeSurfer's ``mri_robust_template``.
         (robust_template, ref_to_nii, [('out_file', 'in_file')]),
         (ref_to_nii, outputnode, [('out_file', 'petref')]),
     ])  # fmt:skip
+
+    if blocking_time is not None:
+        workflow.connect(
+            [
+                (inputnode, stop_frame, [('frame_durations', 'durations'),
+                                         ('frame_start_times', 'frame_starts'),
+                                         ('blocking_time', 'start_time')]),
+                (stop_frame, select_idx, [('start_frame_idx', 'stop_idx')]),
+            ]
+        )
 
     if auto_init_frame:
         workflow.connect(

--- a/petprep/workflows/pet/tests/test_hmc.py
+++ b/petprep/workflows/pet/tests/test_hmc.py
@@ -4,6 +4,7 @@ import pytest
 
 from ..hmc import (
     _find_highest_uptake_frame,
+    _select_estimation_indices,
     get_start_frame,
     init_pet_hmc_wf,
     update_list_transforms,
@@ -31,13 +32,14 @@ def test_get_start_frame_empty():
 
 def test_update_list_transforms_padding():
     xforms = ['a', 'b', 'c']
-    assert update_list_transforms(xforms, 2) == ['a', 'a', 'a', 'b', 'c']
-    assert update_list_transforms(xforms, 0) == xforms
+    assert update_list_transforms(xforms, 2, 5) == ['a', 'a', 'a', 'b', 'c']
+    assert update_list_transforms(xforms, 0, 3) == xforms
+    assert update_list_transforms(xforms, 1, 7) == ['a', 'a', 'b', 'c', 'c', 'c', 'c']
 
 
 def test_update_list_transforms_empty():
     with pytest.raises(ValueError, match='cannot be empty'):
-        update_list_transforms([], 1)
+        update_list_transforms([], 1, 1)
 
 
 def test_init_pet_hmc_wf_nodes():
@@ -77,3 +79,17 @@ def test_find_highest_uptake_frame(tmp_path):
     expected = np.argmax([arr.sum() for arr in data]) + 1
     result = _find_highest_uptake_frame(files)
     assert result == expected
+
+
+def test_select_estimation_indices_with_stop_idx():
+    assert _select_estimation_indices(total_frames=8, start_idx=1, stop_idx=5) == [1, 2, 3, 4]
+
+
+def test_select_estimation_indices_without_stop_idx():
+    assert _select_estimation_indices(total_frames=5, start_idx=2, stop_idx=None) == [2, 3, 4]
+
+
+def test_init_pet_hmc_wf_blocking_time_adds_stop_frame_node():
+    wf = init_pet_hmc_wf(mem_gb=1, omp_nthreads=1, blocking_time=600.0)
+    names = wf.list_node_names()
+    assert 'get_blocking_frame' in names


### PR DESCRIPTION
### Motivation
- Allow excluding frames after a user-specified blocking/challenge onset from head-motion estimation to avoid confounding tracer-kinetic changes with motion.
- Make transform-list expansion robust when motion estimation uses a subset of frames so that returned transform lists always match the original frame count.

### Description
- Add `--hmc-blocking-time` CLI option and corresponding `hmc_blocking_time` config field to expose an optional blocking onset in seconds.
- Thread `blocking_time` through `init_pet_fit_wf` into `init_pet_hmc_wf` and add a `get_blocking_frame` node to compute the stop index when set.
- Introduce `_select_estimation_indices(total_frames, start_idx, stop_idx=None)` to select the indices used for motion estimation and wire it into the `select_indices` node.
- Change `update_list_transforms` signature to `update_list_transforms(xforms, idx, total_frames)` and make it pad both the start and the tail of the transform list so its length equals `total_frames`, and trim if it is longer.
- Update unit tests and add new tests exercising CLI parsing of `--hmc-blocking-time`, the new `_select_estimation_indices` behavior, the updated `update_list_transforms` padding/trimming, and that `init_pet_hmc_wf` adds the `get_blocking_frame` node when `blocking_time` is provided.

### Testing
- Ran updated unit tests for the CLI: `test_hmc_blocking_time_parsing` in `petprep/cli/tests/test_parser.py`, which passed.
- Ran updated HMC unit tests in `petprep/workflows/pet/tests/test_hmc.py`, including `test_select_estimation_indices_with_stop_idx`, `test_select_estimation_indices_without_stop_idx`, `test_update_list_transforms_padding`, and `test_init_pet_hmc_wf_blocking_time_adds_stop_frame_node`, which all passed.
- Existing HMC workflow node checks (`test_init_pet_hmc_wf_*`) were rerun and remained successful.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb27f4a3608330b3646ccb296ef45c)