### PR TITLE
ENH: fix session labeling filtering when sessions.tsv file is present

### DIFF
--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -1063,7 +1063,9 @@ applied."""
         )
 
     if config.execution.session_label:
-        available_sessions = set(get_sessions(config.execution.layout, subject=list(participant_label)))
+        available_sessions = set(
+            get_sessions(config.execution.layout, subject=list(participant_label))
+        )
         missing_sessions = set(config.execution.session_label) - available_sessions
         if missing_sessions:
             parser.error(

--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -26,6 +26,7 @@ import sys
 
 from .. import config
 from ..utils.atlas import load_atlas_config
+from ..utils.bids import get_sessions
 
 
 def _build_parser(**kwargs):
@@ -1062,9 +1063,7 @@ applied."""
         )
 
     if config.execution.session_label:
-        available_sessions = set(
-            config.execution.layout.get_sessions(subject=list(participant_label) or None)
-        )
+        available_sessions = set(get_sessions(config.execution.layout, subject=list(participant_label)))
         missing_sessions = set(config.execution.session_label) - available_sessions
         if missing_sessions:
             parser.error(

--- a/petprep/cli/tests/test_parser.py
+++ b/petprep/cli/tests/test_parser.py
@@ -266,6 +266,53 @@ def test_session_label_only_filters_pet(tmp_path):
         _reset_config()
 
 
+def test_session_label_validation_with_sessions_tsv(tmp_path):
+    bids = tmp_path / 'bids'
+    out_dir = tmp_path / 'out'
+    work_dir = tmp_path / 'work'
+    bids.mkdir()
+    (bids / 'dataset_description.json').write_text('{"Name": "Test", "BIDSVersion": "1.8.0"}')
+    (bids / 'participants.tsv').write_text('participant_id\nsub-01\n')
+
+    sessions_tsv = bids / 'sub-01' / 'sub-01_sessions.tsv'
+    sessions_tsv.parent.mkdir(parents=True, exist_ok=True)
+    sessions_tsv.write_text('session_id\tbody_weight\nses-blocked\t80\n')
+    (bids / 'sub-01' / 'sub-01_sessions.json').write_text(
+        '{"body_weight": {"Description": "body weight", "Units": "kg"}}'
+    )
+
+    anat_path = bids / 'sub-01' / 'ses-blocked' / 'anat' / 'sub-01_ses-blocked_T1w.nii.gz'
+    anat_path.parent.mkdir(parents=True, exist_ok=True)
+    nb.Nifti1Image(np.zeros((5, 5, 5)), np.eye(4)).to_filename(anat_path)
+
+    pet_path = bids / 'sub-01' / 'ses-blocked' / 'pet' / 'sub-01_ses-blocked_pet.nii.gz'
+    pet_path.parent.mkdir(parents=True, exist_ok=True)
+    nb.Nifti1Image(np.zeros((5, 5, 5, 1)), np.eye(4)).to_filename(pet_path)
+    (pet_path.with_suffix('').with_suffix('.json')).write_text(
+        '{"FrameTimesStart": [0], "FrameDuration": [1]}'
+    )
+
+    try:
+        parse_args(
+            args=[
+                str(bids),
+                str(out_dir),
+                'participant',
+                '--participant-label',
+                '01',
+                '--session-label',
+                'blocked',
+                '--skip-bids-validation',
+                '-w',
+                str(work_dir),
+            ]
+        )
+
+        assert config.execution.bids_filters.get('pet', {}).get('session') == ['blocked']
+    finally:
+        _reset_config()
+
+
 def test_tracer_label_only_filters_pet(tmp_path):
     bids = tmp_path / 'bids'
     out_dir = tmp_path / 'out'

--- a/petprep/reports/core.py
+++ b/petprep/reports/core.py
@@ -136,7 +136,9 @@ def generate_reports(
             if session_list is None:
                 all_filters = config.execution.bids_filters or {}
                 filters = all_filters.get('pet', {})
-                session_list = get_sessions(config.execution.layout, subject=subject_label, **filters)
+                session_list = get_sessions(
+                    config.execution.layout, subject=subject_label, **filters
+                )
 
             session_list = [ses.removeprefix('ses-') for ses in session_list]
 

--- a/petprep/reports/core.py
+++ b/petprep/reports/core.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from nireports.assembler.report import Report
 
 from .. import config, data
+from ..utils.bids import get_sessions
 
 
 def run_reports(
@@ -100,7 +101,7 @@ def generate_reports(
         # The number of sessions is intentionally not based on session_list but
         # on the total number of sessions, because I want the final derivatives
         # folder to be the same whether sessions were run one at a time or all-together.
-        n_ses = len(config.execution.layout.get_sessions(subject=subject_label))
+        n_ses = len(get_sessions(config.execution.layout, subject=subject_label))
 
         if bootstrap_file is not None:
             # If a config file is precised, we do not override it
@@ -135,9 +136,7 @@ def generate_reports(
             if session_list is None:
                 all_filters = config.execution.bids_filters or {}
                 filters = all_filters.get('pet', {})
-                session_list = config.execution.layout.get_sessions(
-                    subject=subject_label, **filters
-                )
+                session_list = get_sessions(config.execution.layout, subject=subject_label, **filters)
 
             session_list = [ses.removeprefix('ses-') for ses in session_list]
 

--- a/petprep/reports/tests/test_reports.py
+++ b/petprep/reports/tests/test_reports.py
@@ -1,5 +1,6 @@
 import shutil
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from bids.layout import BIDSLayout
@@ -177,3 +178,30 @@ def test_reportlets_dir_scoped_to_subject(tmp_path, monkeypatch):
     generate_reports(['02'], tmp_path, 'fake', work_dir=work_dir)
 
     assert recorded_reportlets == [target]
+
+
+def test_generate_reports_uses_indexed_session_entities(tmp_path, monkeypatch):
+    recorded_sessions = []
+
+    def _record_report(*args, session=None, **kwargs):
+        recorded_sessions.append(session)
+        return None
+
+    class _Layout:
+        def get(self, return_type='object', subject=None, session=None, **kwargs):
+            assert return_type == 'object'
+            labels = ['001', '003']
+            if session is not None:
+                allowed = session if isinstance(session, list) else [session]
+                labels = [label for label in labels if label in allowed]
+            return [SimpleNamespace(entities={'session': label}) for label in labels]
+
+    monkeypatch.setattr(core, 'run_reports', _record_report)
+    monkeypatch.setattr(config.execution, 'aggr_ses_reports', 1)
+    monkeypatch.setattr(config.execution, 'layout', _Layout())
+    monkeypatch.setattr(config.execution, 'bids_filters', {'pet': {'session': ['001', '003']}})
+
+    failed_reports = generate_reports(['01'], tmp_path, 'fake')
+
+    assert not failed_reports
+    assert recorded_sessions == [None, '001', '001', '003', '003']

--- a/petprep/utils/bids.py
+++ b/petprep/utils/bids.py
@@ -54,7 +54,9 @@ def get_sessions(layout: BIDSLayout, subject=None, **filters) -> list[str]:
         return sorted(layout.get_sessions(subject=subject))
 
     entities = {'subject': subject, **filters}
-    files = layout.get(return_type='object', **{k: v for k, v in entities.items() if v is not None})
+    files = layout.get(
+        return_type='object', **{k: v for k, v in entities.items() if v is not None}
+    )
     sessions = {bids_file.entities.get('session') for bids_file in files}
     return sorted(session for session in sessions if session)
 

--- a/petprep/utils/bids.py
+++ b/petprep/utils/bids.py
@@ -42,6 +42,23 @@ from .. import config
 from ..data import load as load_data
 
 
+def get_sessions(layout: BIDSLayout, subject=None, **filters) -> list[str]:
+    """Collect session labels from indexed file entities.
+
+    PyBIDS can return incorrect values from ``layout.get_sessions()`` when a dataset
+    includes subject-level ``*_sessions.tsv`` files. Reading the ``session`` entity
+    directly from indexed files avoids that collision.
+    """
+
+    if not hasattr(layout, 'get'):
+        return sorted(layout.get_sessions(subject=subject))
+
+    entities = {'subject': subject, **filters}
+    files = layout.get(return_type='object', **{k: v for k, v in entities.items() if v is not None})
+    sessions = {bids_file.entities.get('session') for bids_file in files}
+    return sorted(session for session in sessions if session)
+
+
 @cache
 def _get_layout(derivatives_dir: Path) -> BIDSLayout:
     from petprep.data import load as load_data

--- a/petprep/utils/bids.py
+++ b/petprep/utils/bids.py
@@ -43,15 +43,24 @@ from ..data import load as load_data
 
 
 def get_sessions(layout: BIDSLayout, subject=None, **filters) -> list[str]:
-    """Collect session labels from indexed file entities.
+    """Collect session labels, falling back to indexed file entities when needed.
 
     PyBIDS can return incorrect values from ``layout.get_sessions()`` when a dataset
     includes subject-level ``*_sessions.tsv`` files. Reading the ``session`` entity
     directly from indexed files avoids that collision.
     """
 
-    if not hasattr(layout, 'get'):
-        return sorted(layout.get_sessions(subject=subject))
+    sessions = None
+    if hasattr(layout, 'get_sessions'):
+        try:
+            sessions = layout.get_sessions(subject=subject, **filters)
+        except TypeError:
+            sessions = layout.get_sessions(subject=subject)
+
+    if sessions is not None:
+        normalized = [session.removeprefix('ses-') for session in sessions if isinstance(session, str)]
+        if len(normalized) == len(sessions):
+            return sorted(normalized)
 
     entities = {'subject': subject, **filters}
     files = layout.get(

--- a/petprep/utils/bids.py
+++ b/petprep/utils/bids.py
@@ -61,8 +61,12 @@ def get_sessions(layout: BIDSLayout, subject=None, **filters) -> list[str]:
         normalized = [
             session.removeprefix('ses-') for session in sessions if isinstance(session, str)
         ]
-        if len(normalized) == len(sessions):
+        if normalized:
             return sorted(normalized)
+        if sessions and len(normalized) == len(sessions):
+            return sorted(normalized)
+        if not hasattr(layout, 'get'):
+            return []
 
     entities = {'subject': subject, **filters}
     files = layout.get(

--- a/petprep/utils/bids.py
+++ b/petprep/utils/bids.py
@@ -58,7 +58,9 @@ def get_sessions(layout: BIDSLayout, subject=None, **filters) -> list[str]:
             sessions = layout.get_sessions(subject=subject)
 
     if sessions is not None:
-        normalized = [session.removeprefix('ses-') for session in sessions if isinstance(session, str)]
+        normalized = [
+            session.removeprefix('ses-') for session in sessions if isinstance(session, str)
+        ]
         if len(normalized) == len(sessions):
             return sorted(normalized)
 


### PR DESCRIPTION
This PR addresses issue #289 by implementing a fix to avoid using layout.get_sessions() for validation/report session discovery, and instead derive available sessions from indexed file entities (for example, collecting the session entity from matching files).