### PR TITLE
ENH: add reconstruction filtering support with --rec-label

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -47,6 +47,30 @@ merged with adjusted offsets, and the combined image and metadata are written
 without the ``run`` entity in their filenames. Subsequent preprocessing then
 operates on these merged series rather than the original per-run inputs.
 
+Filtering PET inputs by BIDS entities
+-------------------------------------
+*PETPrep* can restrict which PET series are preprocessed by matching BIDS
+entities in the input filenames. In addition to
+:option:`--participant-label` and :option:`--session-label`, PET-specific
+filters are available through :option:`--tracer-label`, :option:`--rec-label`,
+and :option:`--run-label`.
+
+Use :option:`--rec-label` when a dataset contains multiple reconstruction
+variants for the same acquisition and only a subset should be processed. The
+option accepts one or more reconstruction identifiers, and the ``rec-`` prefix
+is optional. For example, if a dataset includes files such as
+``sub-01_rec-FBP_pet.nii.gz`` and ``sub-01_rec-OSEM_pet.nii.gz``, both can be
+selected explicitly with: ::
+
+    petprep data/bids_root/ out/ participant --rec-label FBP OSEM
+
+The equivalent command with explicit BIDS entity values is also valid: ::
+
+    petprep data/bids_root/ out/ participant --rec-label rec-FBP rec-OSEM
+
+These filters apply to PET inputs only, so anatomical files are still resolved
+using the matching subject and session context.
+
 Command-Line Arguments
 ----------------------
 .. argparse::

--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -209,6 +209,13 @@ def _build_parser(**kwargs):
         'identifier (the trc- prefix can be removed)',
     )
     g_bids.add_argument(
+        '--rec-label',
+        nargs='+',
+        type=lambda label: label.removeprefix('rec-'),
+        help='A space delimited list of reconstruction identifiers or a single '
+        'identifier (the rec- prefix can be removed)',
+    )
+    g_bids.add_argument(
         '--run-label',
         nargs='+',
         type=_run_label,
@@ -856,6 +863,13 @@ def parse_args(args=None, namespace=None):
             'tracer': config.execution.tracer_label,
         }
 
+    if config.execution.rec_label:
+        config.execution.bids_filters = config.execution.bids_filters or {}
+        config.execution.bids_filters['pet'] = {
+            **config.execution.bids_filters.get('pet', {}),
+            'reconstruction': config.execution.rec_label,
+        }
+
     if config.execution.run_label:
         config.execution.bids_filters = config.execution.bids_filters or {}
         config.execution.bids_filters['pet'] = {
@@ -1090,6 +1104,26 @@ applied."""
             parser.error(
                 'One or more tracer labels were not found in the BIDS directory: '
                 f'{", ".join(sorted(missing_tracers))}.'
+            )
+
+    if config.execution.rec_label:
+        rec_filters = (
+            config.execution.bids_filters.get('pet', {}) if config.execution.bids_filters else {}
+        )
+        rec_filters = {key: value for key, value in rec_filters.items() if key != 'reconstruction'}
+        available_recs = set(
+            config.execution.layout.get(
+                target='reconstruction',
+                return_type='id',
+                subject=list(participant_label) or None,
+                **rec_filters,
+            )
+        )
+        missing_recs = set(config.execution.rec_label) - available_recs
+        if missing_recs:
+            parser.error(
+                'One or more reconstruction labels were not found in the BIDS directory: '
+                f'{", ".join(sorted(missing_recs))}.'
             )
 
     if config.execution.run_label:

--- a/petprep/cli/tests/test_parser.py
+++ b/petprep/cli/tests/test_parser.py
@@ -336,6 +336,76 @@ def test_tracer_label_validation(tmp_path):
     _reset_config()
 
 
+def test_rec_label_only_filters_pet(tmp_path):
+    bids = tmp_path / 'bids'
+    out_dir = tmp_path / 'out'
+    work_dir = tmp_path / 'work'
+    bids.mkdir()
+    (bids / 'dataset_description.json').write_text('{"Name": "Test", "BIDSVersion": "1.8.0"}')
+
+    anat_path = bids / 'sub-01' / 'anat' / 'sub-01_T1w.nii.gz'
+    anat_path.parent.mkdir(parents=True, exist_ok=True)
+    nb.Nifti1Image(np.zeros((5, 5, 5)), np.eye(4)).to_filename(anat_path)
+
+    pet_path = bids / 'sub-01' / 'pet' / 'sub-01_rec-acdyn_pet.nii.gz'
+    pet_path.parent.mkdir(parents=True, exist_ok=True)
+    nb.Nifti1Image(np.zeros((5, 5, 5, 1)), np.eye(4)).to_filename(pet_path)
+    (pet_path.with_suffix('').with_suffix('.json')).write_text(
+        '{"FrameTimesStart": [0], "FrameDuration": [1]}'
+    )
+
+    try:
+        parse_args(
+            args=[
+                str(bids),
+                str(out_dir),
+                'participant',
+                '--rec-label',
+                'acdyn',
+                '--skip-bids-validation',
+                '-w',
+                str(work_dir),
+            ]
+        )
+
+        filters = config.execution.bids_filters
+        assert filters.get('pet', {}).get('reconstruction') == ['acdyn']
+        assert 'reconstruction' not in filters.get('anat', {})
+    finally:
+        _reset_config()
+
+
+def test_rec_label_validation(tmp_path):
+    bids = tmp_path / 'bids'
+    out_dir = tmp_path / 'out'
+    work_dir = tmp_path / 'work'
+    bids.mkdir()
+    (bids / 'dataset_description.json').write_text('{"Name": "Test", "BIDSVersion": "1.8.0"}')
+
+    pet_path = bids / 'sub-01' / 'pet' / 'sub-01_rec-acdyn_pet.nii.gz'
+    pet_path.parent.mkdir(parents=True, exist_ok=True)
+    nb.Nifti1Image(np.zeros((5, 5, 5, 1)), np.eye(4)).to_filename(pet_path)
+    (pet_path.with_suffix('').with_suffix('.json')).write_text(
+        '{"FrameTimesStart": [0], "FrameDuration": [1]}'
+    )
+
+    with pytest.raises(SystemExit):
+        parse_args(
+            args=[
+                str(bids),
+                str(out_dir),
+                'participant',
+                '--rec-label',
+                'wrongrec',
+                '--skip-bids-validation',
+                '-w',
+                str(work_dir),
+            ]
+        )
+
+    _reset_config()
+
+
 def test_run_label_only_filters_pet(tmp_path):
     bids = tmp_path / 'bids'
     out_dir = tmp_path / 'out'

--- a/petprep/config.py
+++ b/petprep/config.py
@@ -436,6 +436,8 @@ class execution(_Config):
     """List of session identifiers that are to be preprocessed."""
     tracer_label = None
     """List of tracer identifiers that are to be preprocessed."""
+    rec_label = None
+    """List of reconstruction identifiers that are to be preprocessed."""
     run_label = None
     """List of run identifiers that are to be preprocessed."""
     combine_runs = False


### PR DESCRIPTION
This PR addresses issue #291 to allow for filtering of different PET reconstructions as indicated by the 'rec' entity prior to running the PET workflows. 