### PR TITLE
ENH: add support skipping subjects without T1w or PET data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,10 @@ This tool allows you to easily do the following:
 - Automate and parallelize processing steps, which provides a significant
   speed-up from manual processing or shell-scripted pipelines.
 
+At startup, *PETPrep* checks each selected subject for the required PET and
+T1w inputs. Subjects missing PET and/or T1w data are skipped, and a warning is
+emitted before subject-level workflows are built.
+
 PETPrep also extracts regional time-activity curves as tabular files with frame
 timings and uptake values. These tables can be fed directly into
 pharmacokinetic modeling tools such as kinfitr_ or PMOD_ to estimate tracer kinetics or compute binding estimates.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -15,8 +15,13 @@ Execution and the BIDS format
 The *PETPrep* workflow takes as principal input the path of the dataset
 that is to be processed.
 The input dataset is required to be in valid :abbr:`BIDS (Brain Imaging Data
-Structure)` format, and it must include at least one T1w structural image and
-(unless disabled with a flag) a PET scan.
+Structure)` format. For a subject to be processed, the selected inputs for that
+subject must include at least one T1w structural image and, unless disabled
+with a flag, a PET scan.
+At the beginning of the workflow, *PETPrep* checks each selected subject for
+these required inputs. Subjects missing PET and/or T1w data are skipped, and a
+warning is emitted before subject-level workflows are built. The run only
+errors if no selected subjects remain after these checks.
 We highly recommend that you validate your dataset with the free, online
 `BIDS Validator <https://bids-standard.github.io/bids-validator/>`_.
 

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -7,6 +7,10 @@ Processing pipeline details
 available and are used as the input.
 Certain processing steps will run only when the required metadata is
 available in the input dataset.
+Before any subject-level workflow is initialized, *PETPrep* checks whether each
+selected subject has the required PET and T1w inputs. Subjects missing PET
+and/or T1w data are skipped, and a warning is issued at the start of the run.
+Processing continues for the remaining valid subjects.
 
 A (very) high-level view of the simplest pipeline (for a single dataset with only
 a single tracer and single baseline)

--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -1114,7 +1114,37 @@ applied."""
         config.execution.run_label = sorted(set(config.execution.run_label))
         config.execution.bids_filters['pet']['run'] = config.execution.run_label
 
-    config.execution.participant_label = sorted(participant_label)
+    from ..utils.bids import get_subject_modality_status
+
+    valid_subjects = []
+    for subject_id in sorted(participant_label):
+        status = get_subject_modality_status(
+            bids_dir=config.execution.bids_dir,
+            subject_id=subject_id,
+            bids_filters=config.execution.bids_filters,
+            derivatives=config.execution.derivatives,
+            anat_only=config.workflow.anat_only,
+        )
+        missing = [
+            modality
+            for modality, present in (('PET', status['pet']), ('T1w', status['t1w']))
+            if not present
+        ]
+        if missing:
+            build_log.warning(
+                f"Skipping subject {subject_id}: missing required {' and '.join(missing)} data."
+            )
+            continue
+        valid_subjects.append(subject_id)
+
+    if not valid_subjects:
+        parser.error(
+            'None of the selected participants have the required input data after applying the '
+            'current filters. All selected subjects were skipped because they were missing PET '
+            'and/or T1w data.'
+        )
+
+    config.execution.participant_label = valid_subjects
     config.workflow.skull_strip_template = config.workflow.skull_strip_template[0]
 
     if config.execution.combine_runs:

--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -1132,7 +1132,7 @@ applied."""
         ]
         if missing:
             build_log.warning(
-                f"Skipping subject {subject_id}: missing required {' and '.join(missing)} data."
+                f'Skipping subject {subject_id}: missing required {" and ".join(missing)} data.'
             )
             continue
         valid_subjects.append(subject_id)

--- a/petprep/cli/tests/test_parser.py
+++ b/petprep/cli/tests/test_parser.py
@@ -160,6 +160,81 @@ def test_parse_args(tmp_path, minimal_bids):
     _reset_config()
 
 
+def test_parse_args_skips_subjects_missing_pet_or_t1w(tmp_path):
+    bids = tmp_path / 'bids'
+    out_dir = tmp_path / 'out'
+    work_dir = tmp_path / 'work'
+    bids.mkdir()
+    (bids / 'dataset_description.json').write_text('{"Name": "Test", "BIDSVersion": "1.8.0"}')
+
+    img3d = nb.Nifti1Image(np.zeros((5, 5, 5)), np.eye(4))
+    img4d = nb.Nifti1Image(np.zeros((5, 5, 5, 1)), np.eye(4))
+
+    t1w_01 = bids / 'sub-01' / 'anat' / 'sub-01_T1w.nii.gz'
+    t1w_01.parent.mkdir(parents=True, exist_ok=True)
+    img3d.to_filename(t1w_01)
+    pet_01 = bids / 'sub-01' / 'pet' / 'sub-01_pet.nii.gz'
+    pet_01.parent.mkdir(parents=True, exist_ok=True)
+    img4d.to_filename(pet_01)
+    (pet_01.with_suffix('').with_suffix('.json')).write_text(
+        '{"FrameTimesStart": [0], "FrameDuration": [1]}'
+    )
+
+    pet_02 = bids / 'sub-02' / 'pet' / 'sub-02_pet.nii.gz'
+    pet_02.parent.mkdir(parents=True, exist_ok=True)
+    img4d.to_filename(pet_02)
+    (pet_02.with_suffix('').with_suffix('.json')).write_text(
+        '{"FrameTimesStart": [0], "FrameDuration": [1]}'
+    )
+
+    t1w_03 = bids / 'sub-03' / 'anat' / 'sub-03_T1w.nii.gz'
+    t1w_03.parent.mkdir(parents=True, exist_ok=True)
+    img3d.to_filename(t1w_03)
+
+    try:
+        parse_args(
+            args=[
+                str(bids),
+                str(out_dir),
+                'participant',
+                '--skip-bids-validation',
+                '-w',
+                str(work_dir),
+            ]
+        )
+
+        assert config.execution.participant_label == ['01']
+    finally:
+        _reset_config()
+
+
+def test_parse_args_errors_when_all_subjects_missing_required_modalities(tmp_path):
+    bids = tmp_path / 'bids'
+    out_dir = tmp_path / 'out'
+    work_dir = tmp_path / 'work'
+    bids.mkdir()
+    (bids / 'dataset_description.json').write_text('{"Name": "Test", "BIDSVersion": "1.8.0"}')
+
+    img3d = nb.Nifti1Image(np.zeros((5, 5, 5)), np.eye(4))
+    t1w_01 = bids / 'sub-01' / 'anat' / 'sub-01_T1w.nii.gz'
+    t1w_01.parent.mkdir(parents=True, exist_ok=True)
+    img3d.to_filename(t1w_01)
+
+    with pytest.raises(SystemExit):
+        parse_args(
+            args=[
+                str(bids),
+                str(out_dir),
+                'participant',
+                '--skip-bids-validation',
+                '-w',
+                str(work_dir),
+            ]
+        )
+
+    _reset_config()
+
+
 def test_bids_filter_file(tmp_path, capsys):
     bids_path = tmp_path / 'data'
     out_path = tmp_path / 'out'

--- a/petprep/conftest.py
+++ b/petprep/conftest.py
@@ -47,4 +47,11 @@ def minimal_bids(tmp_path):
     T1w = bids / 'sub-01' / 'anat' / 'sub-01_T1w.nii.gz'
     T1w.parent.mkdir(parents=True)
     nb.Nifti1Image(np.zeros((5, 5, 5)), np.eye(4)).to_filename(T1w)
+    pet = bids / 'sub-01' / 'pet' / 'sub-01_pet.nii.gz'
+    pet.parent.mkdir(parents=True, exist_ok=True)
+    nb.Nifti1Image(np.zeros((5, 5, 5, 1)), np.eye(4)).to_filename(pet)
+    Path.write_text(
+        pet.with_suffix('').with_suffix('.json'),
+        json.dumps({'FrameTimesStart': [0], 'FrameDuration': [1]}),
+    )
     return bids

--- a/petprep/utils/bids.py
+++ b/petprep/utils/bids.py
@@ -24,6 +24,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import os
 import re
@@ -328,6 +329,46 @@ def combine_pet_runs(bids_dir: Path, layout: BIDSLayout, work_dir: Path, subject
             combined_files.append(str(output_img))
 
     return combined_root, combined_files
+
+
+def get_subject_modality_status(
+    bids_dir: Path,
+    subject_id: str,
+    *,
+    bids_filters: dict | None = None,
+    derivatives: dict | None = None,
+    anat_only: bool = False,
+) -> dict[str, bool]:
+    """Return subject-level PET/T1w availability after applying active filters."""
+    from niworkflows.utils.bids import DEFAULT_BIDS_QUERIES, collect_data
+
+    queries = copy.deepcopy(DEFAULT_BIDS_QUERIES)
+    queries['t1w'].pop('datatype', None)
+    subject_data = collect_data(
+        bids_dir,
+        subject_id,
+        bids_filters=bids_filters,
+        queries=queries,
+    )[0]
+
+    has_pet = anat_only or bool(subject_data['pet'])
+    has_t1w = bool(subject_data['t1w'])
+
+    if not has_t1w and derivatives:
+        from smriprep.utils.bids import collect_derivatives as collect_anat_derivatives
+
+        anatomical_cache = {}
+        for deriv_dir in derivatives.values():
+            anatomical_cache.update(
+                collect_anat_derivatives(
+                    derivatives_dir=deriv_dir,
+                    subject_id=subject_id,
+                    std_spaces=[],
+                )
+            )
+        has_t1w = 't1w_preproc' in anatomical_cache
+
+    return {'pet': has_pet, 't1w': has_t1w}
 
 
 def validate_input_dir(exec_env, bids_dir, participant_label, need_T1w=True):

--- a/petprep/workflows/base.py
+++ b/petprep/workflows/base.py
@@ -67,6 +67,8 @@ def init_petprep_wf():
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
     from niworkflows.interfaces.bids import BIDSFreeSurferDir
 
+    from ..utils.bids import get_subject_modality_status
+
     ver = Version(config.environment.version)
 
     petprep_wf = Workflow(name=f'petprep_{ver.major}_{ver.minor}_wf')
@@ -87,7 +89,33 @@ def init_petprep_wf():
         if config.execution.fs_subjects_dir is not None:
             fsdir.inputs.subjects_dir = str(config.execution.fs_subjects_dir.absolute())
 
+    valid_subjects = []
     for subject_id in config.execution.participant_label:
+        status = get_subject_modality_status(
+            bids_dir=config.execution.bids_dir,
+            subject_id=subject_id,
+            bids_filters=config.execution.bids_filters,
+            derivatives=config.execution.derivatives,
+            anat_only=config.workflow.anat_only,
+        )
+        missing = [
+            modality
+            for modality, present in (('PET', status['pet']), ('T1w', status['t1w']))
+            if not present
+        ]
+        if missing:
+            config.loggers.workflow.warning(
+                f"Skipping subject {subject_id}: missing required {' and '.join(missing)} data."
+            )
+            continue
+        valid_subjects.append(subject_id)
+
+    if not valid_subjects:
+        raise RuntimeError(
+            'No subjects with the required PET and T1w inputs remain after subject-level checks.'
+        )
+
+    for subject_id in valid_subjects:
         single_subject_wf = init_single_subject_wf(subject_id)
 
         single_subject_wf.config['execution']['crashdump_dir'] = str(

--- a/petprep/workflows/base.py
+++ b/petprep/workflows/base.py
@@ -105,7 +105,7 @@ def init_petprep_wf():
         ]
         if missing:
             config.loggers.workflow.warning(
-                f"Skipping subject {subject_id}: missing required {' and '.join(missing)} data."
+                f'Skipping subject {subject_id}: missing required {" and ".join(missing)} data.'
             )
             continue
         valid_subjects.append(subject_id)

--- a/petprep/workflows/tests/test_base.py
+++ b/petprep/workflows/tests/test_base.py
@@ -31,6 +31,19 @@ BASE_LAYOUT = {
     },
 }
 
+MIXED_LAYOUT = {
+    '01': {
+        'anat': [{'suffix': 'T1w'}],
+        'pet': [{'suffix': 'pet', 'metadata': {}}],
+    },
+    '02': {
+        'pet': [{'suffix': 'pet', 'metadata': {}}],
+    },
+    '03': {
+        'anat': [{'suffix': 'T1w'}],
+    },
+}
+
 
 @pytest.fixture(scope='module')
 def custom_queries():
@@ -103,6 +116,35 @@ def multisession_bids_root(tmp_path_factory):
     return bids_dir
 
 
+@pytest.fixture(scope='module')
+def mixed_bids_root(tmp_path_factory):
+    base = tmp_path_factory.mktemp('mixed-subjects')
+    bids_dir = base / 'bids'
+    generate_bids_skeleton(bids_dir, MIXED_LAYOUT)
+
+    img3d = nb.Nifti1Image(np.zeros((10, 10, 10)), np.eye(4))
+    img4d = nb.Nifti1Image(np.zeros((10, 10, 10, 10)), np.eye(4))
+
+    anat_dir = bids_dir / 'sub-01' / 'anat'
+    anat_dir.mkdir(parents=True, exist_ok=True)
+    img3d.to_filename(anat_dir / 'sub-01_T1w.nii.gz')
+
+    for subject_id in ('01', '02'):
+        pet_dir = bids_dir / f'sub-{subject_id}' / 'pet'
+        pet_dir.mkdir(parents=True, exist_ok=True)
+        pet_path = pet_dir / f'sub-{subject_id}_pet.nii.gz'
+        img4d.to_filename(pet_path)
+        (pet_path.with_suffix('').with_suffix('.json')).write_text(
+            json.dumps({'FrameTimesStart': [0], 'FrameDuration': [1]})
+        )
+
+    anat_dir = bids_dir / 'sub-03' / 'anat'
+    anat_dir.mkdir(parents=True, exist_ok=True)
+    img3d.to_filename(anat_dir / 'sub-03_T1w.nii.gz')
+
+    return bids_dir
+
+
 def test_segmentation_shared_across_runs(multisession_bids_root):
     with mock_config(bids_dir=multisession_bids_root):
         wf = init_single_subject_wf('01')
@@ -127,6 +169,16 @@ def test_segmentation_shared_across_runs(multisession_bids_root):
         assert ('outputnode.segmentation', 'inputnode.segmentation') in edge['connect']
         assert ('outputnode.dseg_tsv', 'inputnode.dseg_tsv') in edge['connect']
         assert all('_seg_wf' not in n for n in pet_node.list_node_names())
+
+
+def test_init_petprep_wf_skips_subjects_missing_required_modalities(mixed_bids_root):
+    with mock_config(bids_dir=mixed_bids_root):
+        config.execution.participant_label = ['01', '02', '03']
+        wf = init_petprep_wf()
+
+    assert any(name.startswith('sub_01_wf.') for name in wf.list_node_names())
+    assert not any(name.startswith('sub_02_wf.') for name in wf.list_node_names())
+    assert not any(name.startswith('sub_03_wf.') for name in wf.list_node_names())
 
 
 def _make_params(


### PR DESCRIPTION
This PR addresses issue #293 by skipping subjects with missing PET and/or T1w inputs instead of failing the full PETPrep run.