### PR TITLE
FIX: Collapse --petref auto to template for 3D PET inputs

### DIFF
--- a/petprep/workflows/pet/fit.py
+++ b/petprep/workflows/pet/fit.py
@@ -536,14 +536,20 @@ def init_pet_fit_wf(
     petref_strategy = requested_petref_strategy
     petref_candidates = None
     petref_candidate_labels: list[str] = []
-    if requested_petref_strategy == 'auto':
+    if pet_tlen <= 1 and requested_petref_strategy == 'auto':
+        petref_strategy = 'template'
+        config.loggers.workflow.info(
+            '3D PET file detected; using the input image as the PET reference instead of '
+            'building multiple auto PET references.'
+        )
+    elif requested_petref_strategy == 'auto':
         petref_strategy = 'auto'
         petref_candidate_labels = ['template', 'twa', 'sum', 'first5min']
         petref_candidates = pe.Node(
             niu.IdentityInterface(fields=petref_candidate_labels), name='petref_candidates'
         )
 
-    if hmc_disabled and petref_strategy == 'template':
+    if pet_tlen > 1 and hmc_disabled and petref_strategy == 'template':
         config.loggers.workflow.warning(
             'Head motion correction disabled (--hmc-off); using a time-weighted average '
             'reference instead of the motion correction template.'

--- a/petprep/workflows/pet/tests/test_fit.py
+++ b/petprep/workflows/pet/tests/test_fit.py
@@ -273,6 +273,81 @@ def test_petref_default_twa_when_hmc_disabled(bids_root: Path, tmp_path: Path):
     assert summary.inputs.hmc_disabled is True
 
 
+def test_petref_auto_uses_template_for_3d_pet(bids_root: Path, tmp_path: Path):
+    """3D PET data should not fan out into redundant auto reference candidates."""
+    from ....utils.misc import estimate_pet_mem_usage
+
+    pet_series = [str(bids_root / 'sub-01' / 'pet' / 'sub-01_task-rest_run-1_pet.nii.gz')]
+    img = nb.Nifti1Image(np.zeros((2, 2, 2), dtype=np.float32), np.eye(4))
+    for path in pet_series:
+        img.to_filename(path)
+
+    sidecar = Path(pet_series[0]).with_suffix('').with_suffix('.json')
+    sidecar.write_text('{"FrameTimesStart": [0], "FrameDuration": [1]}')
+
+    estimate_pet_mem_usage.cache_clear()
+    try:
+        with mock_config(bids_dir=bids_root):
+            config.workflow.petref = 'auto'
+            wf = init_pet_fit_wf(pet_series=pet_series, precomputed={}, omp_nthreads=1)
+    finally:
+        estimate_pet_mem_usage.cache_clear()
+
+    node_names = wf.list_node_names()
+    assert 'petref_candidates' not in node_names
+    assert 'select_best_petref' not in node_names
+    assert 'auto_twa_reference' not in node_names
+    assert 'auto_sum_reference' not in node_names
+    assert 'auto_first5min_reference' not in node_names
+    assert any(name.startswith('pet_reg_wf.') for name in node_names)
+    assert not any(name.startswith('pet_reg_wf_') for name in node_names)
+
+    petref_buffer = wf.get_node('petref_buffer')
+    assert petref_buffer.inputs.petref == pet_series[0]
+
+    summary = wf.get_node('summary')
+    assert summary.inputs.petref_strategy == 'template'
+    assert summary.inputs.requested_petref_strategy == 'auto'
+
+
+def test_petref_auto_mixed_3d_and_4d_pet_runs(bids_root: Path, tmp_path: Path):
+    """The 3D auto shortcut is decided per PET workflow, not globally."""
+    from ....utils.misc import estimate_pet_mem_usage
+
+    pet_dir = bids_root / 'sub-01' / 'pet'
+    pet_3d = pet_dir / 'sub-01_task-rest_run-1_pet.nii.gz'
+    pet_4d = pet_dir / 'sub-01_task-rest_run-2_pet.nii.gz'
+
+    nb.Nifti1Image(np.zeros((2, 2, 2), dtype=np.float32), np.eye(4)).to_filename(pet_3d)
+    nb.Nifti1Image(np.zeros((2, 2, 2, 2), dtype=np.float32), np.eye(4)).to_filename(pet_4d)
+    pet_3d.with_suffix('').with_suffix('.json').write_text(
+        '{"FrameTimesStart": [0], "FrameDuration": [1]}'
+    )
+    pet_4d.with_suffix('').with_suffix('.json').write_text(
+        '{"FrameTimesStart": [0, 1], "FrameDuration": [1, 1]}'
+    )
+
+    estimate_pet_mem_usage.cache_clear()
+    try:
+        with mock_config(bids_dir=bids_root):
+            config.workflow.petref = 'auto'
+            wf_3d = init_pet_fit_wf(pet_series=[str(pet_3d)], precomputed={}, omp_nthreads=1)
+            wf_4d = init_pet_fit_wf(pet_series=[str(pet_4d)], precomputed={}, omp_nthreads=1)
+    finally:
+        estimate_pet_mem_usage.cache_clear()
+
+    node_names_3d = wf_3d.list_node_names()
+    node_names_4d = wf_4d.list_node_names()
+
+    assert 'petref_candidates' not in node_names_3d
+    assert 'select_best_petref' not in node_names_3d
+    assert 'petref_candidates' in node_names_4d
+    assert 'select_best_petref' in node_names_4d
+
+    assert wf_3d.get_node('summary').inputs.petref_strategy == 'template'
+    assert wf_4d.get_node('summary').inputs.petref_strategy == 'auto'
+
+
 def test_pet_reference_utilities(tmp_path: Path):
     labels = ['template', 'twa', 'sum']
     scores = [0.5, None, 0.25]


### PR DESCRIPTION
This PR addresses issue #305, avoiding redundant PET reference generation and coregistration workflows when --petref auto (default) is used with 3D PET data.

For 3D PET inputs, the automatic PET reference candidates template, twa, sum, and first5min are equivalent because there is only one volume. The workflow now detects this case during PET workflow initialization and uses template as the effective PET reference strategy instead of constructing the full auto candidate workflow.

The originally requested strategy is still preserved in reporting/logging, so reports can indicate that auto was requested while template was used for the 3D input.

This keeps existing behavior unchanged for 4D PET data, where --petref auto still evaluates the full set of PET reference candidates. The decision is made per PET workflow, so mixed datasets with both 3D and 4D PET runs are handled correctly.