### PR TITLE
ENH: add support for corpus callosum (cc) segmentation

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -284,13 +284,21 @@ Segmentation
 ------------
 *PETPrep* can segment the brain into different brain regions and extract time activity curves from these regions.
 The ``--seg`` flag selects the segmentation method to use.
-Available options are ``gtm`` (default) whole-brain segmentation from FreeSurfer, ``brainstem``, ``wm`` (white matter), ``thalamicNuclei``, ``hippocampusAmygdala``, ``raphe``, and ``limbic``. Atlas-based segmentations can also be selected with ``--seg``; the atlas choices are ``HOCPA`` (harvard-oxford atlas), the Schaefer 2018 atlas variants listed in `Atlas Segmentation`_, and ``MASSP20`` (subcortical atlas). When an atlas is selected, *PETPrep* automatically adds the atlas template to ``--output-spaces`` and warps the atlas and its label file into anatomical space. For more information about the atlas choices, see the section `Atlas Segmentation`_.
+Available options are ``gtm`` (default) whole-brain segmentation from FreeSurfer, ``brainstem``, ``wm`` (white matter), ``cc`` (corpus callosum), ``thalamicNuclei``, ``hippocampusAmygdala``, ``raphe``, and ``limbic``. Atlas-based segmentations can also be selected with ``--seg``; the atlas choices are ``HOCPA`` (harvard-oxford atlas), the Schaefer 2018 atlas variants listed in `Atlas Segmentation`_, and ``MASSP20`` (subcortical atlas). When an atlas is selected, *PETPrep* automatically adds the atlas template to ``--output-spaces`` and warps the atlas and its label file into anatomical space. For more information about the atlas choices, see the section `Atlas Segmentation`_.
 The ``gtm`` segmentation is a whole-brain segmentation that includes the
 cerebral cortex, subcortical structures, and cerebellum.
+The ``cc`` segmentation runs FreeSurfer's ``mri_cc`` on the subject's
+``aseg.mgz`` and divides the corpus callosum into five labels:
+``CC_Posterior`` (251), ``CC_Mid_Posterior`` (252), ``CC_Central`` (253),
+``CC_Mid_Anterior`` (254), and ``CC_Anterior`` (255).
 
 To run the segmentation with the default ``gtm`` method, use: ::
 
     $ petprep /data/bids_root /out participant --seg gtm 
+
+To run corpus callosum segmentation, use: ::
+
+    $ petprep /data/bids_root /out participant --seg cc
 
 Atlas Segmentation
 ------------------

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -537,10 +537,16 @@ Segmentation workflows
 *PETPrep* ships with optional segmentation routines that can be selected via
 the ``--seg`` command-line argument. Supported values include ``gtm`` (the
 default), ``brainstem``, ``thalamicNuclei``, ``hippocampusAmygdala``, ``wm``,
-``raphe`` and ``limbic``. Atlas-based segmentations may also be selected with
-``--seg``; these include ``HOCPA``, ``MASSP20`` and the
+``cc``, ``raphe`` and ``limbic``. Atlas-based segmentations may also be
+selected with ``--seg``; these include ``HOCPA``, ``MASSP20`` and the
 ``Schaefer2018<N>Parcels7Networks`` and
 ``Schaefer2018<N>Parcels17Networks`` variants described in :doc:`usage`.
+
+The ``cc`` workflow wraps FreeSurfer's ``mri_cc`` command. It reads the
+subject's ``aseg.mgz`` from the FreeSurfer ``mri/`` directory, writes an
+``aseg.auto_CCseg.mgz`` volume with the corpus callosum subdivisions, and then
+converts the result to the standard *PETPrep* segmentation derivatives. The
+five output labels correspond to the FreeSurfer corpus callosum labels 251-255.
 
 Tool-based segmentations rely on pretrained models distributed with
 ``petprep.data.segmentation``. The first time a particular model is requested it

--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -649,6 +649,7 @@ https://petprep.readthedocs.io/en/{currentv.base_version if is_release else 'lat
         'thalamicNuclei',
         'hippocampusAmygdala',
         'wm',
+        'cc',
         'raphe',
         'limbic',
         *sorted(atlas_config.keys()),

--- a/petprep/interfaces/segmentation.py
+++ b/petprep/interfaces/segmentation.py
@@ -361,6 +361,82 @@ class SegmentWM(SimpleInterface):
         return proc.stdout, proc.stderr
 
 
+class SegmentCCInputSpec(BaseInterfaceInputSpec):
+    subjects_dir = Directory(exists=True, mandatory=True, desc='FreeSurfer subjects directory')
+    subject_id = traits.Str(mandatory=True, desc='Subject identifier')
+    aseg_file = traits.Str('aseg.mgz', usedefault=True, desc='Input aseg volume in subject mri dir')
+    out_file = traits.Str(
+        'aseg.auto_CCseg.mgz',
+        usedefault=True,
+        desc='Output aseg volume including corpus callosum labels',
+    )
+    lta_file = traits.Str(desc='Write rotation LTA to this filename')
+    include_fornix = traits.Bool(desc='Include fornix in segmentation')
+    force = traits.Bool(desc='Process regardless of existing CC labels in input')
+    subdivisions = traits.Int(desc='Number of corpus callosum segments')
+    thickness = traits.Int(desc='Distance in mm to extend CC off the midline')
+    skip = traits.Int(desc='Number of voxels to skip in rotational alignment')
+    max_rotation = traits.Float(desc='Maximum rotation search in degrees')
+
+
+class SegmentCCOutputSpec(TraitedSpec):
+    out_file = File(exists=True, desc='Aseg volume including corpus callosum labels')
+    lta_file = File(desc='Rotation LTA written by mri_cc')
+    stdout = traits.Str(desc='Standard output')
+    stderr = traits.Str(desc='Standard error output')
+
+
+class SegmentCC(SimpleInterface):
+    """Run ``mri_cc`` unless the corpus callosum segmentation already exists."""
+
+    input_spec = SegmentCCInputSpec
+    output_spec = SegmentCCOutputSpec
+
+    def _run_interface(self, runtime):
+        subj_dir = Path(self.inputs.subjects_dir) / self.inputs.subject_id / 'mri'
+        out_file = subj_dir / self.inputs.out_file
+
+        if not out_file.exists():
+            cmd = [
+                'mri_cc',
+                '-aseg',
+                self.inputs.aseg_file,
+                '-o',
+                self.inputs.out_file,
+                '-sdir',
+                str(self.inputs.subjects_dir),
+            ]
+
+            if isdefined(self.inputs.lta_file):
+                cmd += ['-lta', self.inputs.lta_file]
+            if self.inputs.include_fornix:
+                cmd.append('-f')
+            if self.inputs.force:
+                cmd.append('-force')
+            if isdefined(self.inputs.subdivisions):
+                cmd += ['-d', str(self.inputs.subdivisions)]
+            if isdefined(self.inputs.thickness):
+                cmd += ['-t', str(self.inputs.thickness)]
+            if isdefined(self.inputs.skip):
+                cmd += ['-s', str(self.inputs.skip)]
+            if isdefined(self.inputs.max_rotation):
+                cmd += ['-m', str(self.inputs.max_rotation)]
+
+            cmd.append(self.inputs.subject_id)
+            self._results['stdout'], self._results['stderr'] = self._run_command(cmd)
+        else:
+            runtime.returncode = 0
+
+        self._results['out_file'] = str(out_file)
+        if isdefined(self.inputs.lta_file):
+            self._results['lta_file'] = str(Path(self.inputs.lta_file).absolute())
+        return runtime
+
+    def _run_command(self, cmd):
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        return proc.stdout, proc.stderr
+
+
 class SegmentGTM(GTMSeg):
     """Run ``gtmseg`` unless outputs already exist."""
 

--- a/petprep/interfaces/segmentation.py
+++ b/petprep/interfaces/segmentation.py
@@ -364,7 +364,9 @@ class SegmentWM(SimpleInterface):
 class SegmentCCInputSpec(BaseInterfaceInputSpec):
     subjects_dir = Directory(exists=True, mandatory=True, desc='FreeSurfer subjects directory')
     subject_id = traits.Str(mandatory=True, desc='Subject identifier')
-    aseg_file = traits.Str('aseg.mgz', usedefault=True, desc='Input aseg volume in subject mri dir')
+    aseg_file = traits.Str(
+        'aseg.mgz', usedefault=True, desc='Input aseg volume in subject mri dir'
+    )
     out_file = traits.Str(
         'aseg.auto_CCseg.mgz',
         usedefault=True,

--- a/petprep/interfaces/tests/test_segmentation_interface.py
+++ b/petprep/interfaces/tests/test_segmentation_interface.py
@@ -5,6 +5,7 @@ from ... import config
 from ..segmentation import (
     MRISclimbicSeg,
     SegmentBS,
+    SegmentCC,
     SegmentGTM,
     SegmentHA_T1,
     SegmentThalamicNuclei,
@@ -62,6 +63,14 @@ def _fake_wm_run(self, cmd):
     return 'wm out', 'wm err'
 
 
+def _fake_cc_run(self, cmd):
+    subj_dir = Path(self.inputs.subjects_dir) / self.inputs.subject_id / 'mri'
+    subj_dir.mkdir(parents=True, exist_ok=True)
+    (subj_dir / self.inputs.out_file).write_text('')
+    self._cmd = cmd
+    return 'cc out', 'cc err'
+
+
 def test_segmentbs_stdout_stderr(monkeypatch, tmp_path):
     seg = SegmentBS(subjects_dir=str(tmp_path), subject_id='sub-01')
     monkeypatch.setattr(SegmentBS, '_run_command', _fake_bs_run)
@@ -80,6 +89,37 @@ def test_segmentwm_stdout_stderr(monkeypatch, tmp_path):
     res = seg.run()
     assert res.outputs.stdout == 'wm out'
     assert res.outputs.stderr == 'wm err'
+
+
+def test_segmentcc_stdout_stderr_and_command(monkeypatch, tmp_path):
+    seg = SegmentCC(
+        subjects_dir=str(tmp_path),
+        subject_id='sub-01',
+        force=True,
+        subdivisions=5,
+        thickness=2,
+    )
+    monkeypatch.setattr(SegmentCC, '_run_command', _fake_cc_run)
+    res = seg.run()
+
+    assert res.outputs.stdout == 'cc out'
+    assert res.outputs.stderr == 'cc err'
+    assert Path(res.outputs.out_file) == tmp_path / 'sub-01' / 'mri' / 'aseg.auto_CCseg.mgz'
+    assert seg._cmd == [
+        'mri_cc',
+        '-aseg',
+        'aseg.mgz',
+        '-o',
+        'aseg.auto_CCseg.mgz',
+        '-sdir',
+        str(tmp_path),
+        '-force',
+        '-d',
+        '5',
+        '-t',
+        '2',
+        'sub-01',
+    ]
 
 
 def test_set_freesurfer_seed_runtime():
@@ -183,6 +223,23 @@ def test_segment_thalamic_skips_when_outputs_exist(monkeypatch, tmp_path):
     assert res.runtime.returncode == 0
     assert Path(res.outputs.out_file) == subj_dir / 'ThalamicNuclei.v13.T1.FSvoxelSpace.mgz'
     assert Path(res.outputs.volumes_file) == subj_dir / 'ThalamicNuclei.v13.T1.volumes.txt'
+
+
+def test_segmentcc_skips_when_output_exists(monkeypatch, tmp_path):
+    subj_dir = tmp_path / 'sub-01' / 'mri'
+    subj_dir.mkdir(parents=True)
+    (subj_dir / 'aseg.auto_CCseg.mgz').write_text('')
+
+    def _raise_if_called(*_args, **_kwargs):
+        raise AssertionError('Corpus callosum command should not run when output exists.')
+
+    monkeypatch.setattr(SegmentCC, '_run_command', _raise_if_called)
+
+    seg = SegmentCC(subjects_dir=str(tmp_path), subject_id='sub-01')
+    res = seg.run()
+
+    assert res.runtime.returncode == 0
+    assert Path(res.outputs.out_file) == subj_dir / 'aseg.auto_CCseg.mgz'
 
 
 def test_segmentha_t1_skip_and_filename(tmp_path):

--- a/petprep/interfaces/tests/test_segmentation_interface.py
+++ b/petprep/interfaces/tests/test_segmentation_interface.py
@@ -92,12 +92,17 @@ def test_segmentwm_stdout_stderr(monkeypatch, tmp_path):
 
 
 def test_segmentcc_stdout_stderr_and_command(monkeypatch, tmp_path):
+    lta_file = tmp_path / 'cc.lta'
     seg = SegmentCC(
         subjects_dir=str(tmp_path),
         subject_id='sub-01',
+        lta_file=str(lta_file),
+        include_fornix=True,
         force=True,
         subdivisions=5,
         thickness=2,
+        skip=3,
+        max_rotation=4.5,
     )
     monkeypatch.setattr(SegmentCC, '_run_command', _fake_cc_run)
     res = seg.run()
@@ -105,6 +110,7 @@ def test_segmentcc_stdout_stderr_and_command(monkeypatch, tmp_path):
     assert res.outputs.stdout == 'cc out'
     assert res.outputs.stderr == 'cc err'
     assert Path(res.outputs.out_file) == tmp_path / 'sub-01' / 'mri' / 'aseg.auto_CCseg.mgz'
+    assert Path(res.outputs.lta_file) == lta_file
     assert seg._cmd == [
         'mri_cc',
         '-aseg',
@@ -113,13 +119,37 @@ def test_segmentcc_stdout_stderr_and_command(monkeypatch, tmp_path):
         'aseg.auto_CCseg.mgz',
         '-sdir',
         str(tmp_path),
+        '-lta',
+        str(lta_file),
+        '-f',
         '-force',
         '-d',
         '5',
         '-t',
         '2',
+        '-s',
+        '3',
+        '-m',
+        '4.5',
         'sub-01',
     ]
+
+
+def test_segmentcc_run_command(monkeypatch, tmp_path):
+    seg = SegmentCC(subjects_dir=str(tmp_path), subject_id='sub-01')
+
+    def _fake_subprocess_run(cmd, capture_output, text):
+        assert cmd == ['mri_cc', 'sub-01']
+        assert capture_output is True
+        assert text is True
+        return SimpleNamespace(stdout='cc out', stderr='cc err')
+
+    monkeypatch.setattr('subprocess.run', _fake_subprocess_run)
+
+    stdout, stderr = seg._run_command(['mri_cc', 'sub-01'])
+
+    assert stdout == 'cc out'
+    assert stderr == 'cc err'
 
 
 def test_set_freesurfer_seed_runtime():
@@ -229,16 +259,19 @@ def test_segmentcc_skips_when_output_exists(monkeypatch, tmp_path):
     subj_dir = tmp_path / 'sub-01' / 'mri'
     subj_dir.mkdir(parents=True)
     (subj_dir / 'aseg.auto_CCseg.mgz').write_text('')
+    calls = {'run': 0}
 
-    def _raise_if_called(*_args, **_kwargs):
-        raise AssertionError('Corpus callosum command should not run when output exists.')
+    def _record_call(*_args, **_kwargs):
+        calls['run'] += 1
+        return 'cc out', 'cc err'
 
-    monkeypatch.setattr(SegmentCC, '_run_command', _raise_if_called)
+    monkeypatch.setattr(SegmentCC, '_run_command', _record_call)
 
     seg = SegmentCC(subjects_dir=str(tmp_path), subject_id='sub-01')
     res = seg.run()
 
     assert res.runtime.returncode == 0
+    assert calls['run'] == 0
     assert Path(res.outputs.out_file) == subj_dir / 'aseg.auto_CCseg.mgz'
 
 

--- a/petprep/workflows/pet/segmentation.py
+++ b/petprep/workflows/pet/segmentation.py
@@ -17,6 +17,7 @@ from ...interfaces.bids import BIDSURI
 from ...interfaces.segmentation import (
     MRISclimbicSeg,
     SegmentBS,
+    SegmentCC,
     SegmentGTM,
     SegmentHA_T1,
     SegmentThalamicNuclei,
@@ -95,6 +96,11 @@ SEGMENTATIONS = {
     'wm': {
         'interface': SegmentWM,
         'desc': 'whiteMatter',
+        'inputs': [('subjects_dir', 'subjects_dir'), ('subject_id', 'subject_id')],
+    },
+    'cc': {
+        'interface': SegmentCC,
+        'desc': 'cc',
         'inputs': [('subjects_dir', 'subjects_dir'), ('subject_id', 'subject_id')],
     },
     'raphe': {

--- a/petprep/workflows/pet/tests/test_segmentation.py
+++ b/petprep/workflows/pet/tests/test_segmentation.py
@@ -21,6 +21,12 @@ def test_segmentation_node_selection():
         assert 'create_wm_dsegtsv' in names_wm
         assert 'create_wm_morphtsv' in names_wm
 
+        wf_cc = init_segmentation_wf('cc')
+        names_cc = [n.name for n in wf_cc._get_all_nodes()]
+        assert 'run_cc' in names_cc
+        assert 'convert_ccseg' in names_cc
+        assert 'segstats_cc' in names_cc
+
 
 def test_merge_ha_labels(tmp_path):
     """Merged volume should match input geometry."""


### PR DESCRIPTION
This PR addresses #312, by adding support for corpus callosum segmentation through FreeSurfer’s mri_cc.

Changes include:

1. Adds a new SegmentCC interface wrapping mri_cc.
2. Registers cc as a supported --seg option.
3. Integrates the workflow with the existing segmentation derivative outputs.
4. Documents the new --seg cc option in the usage and workflow docs.