### PR TITLE
ENH: Add aparc+aseg segmentation and corpus callosum reference mask

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -284,7 +284,7 @@ Segmentation
 ------------
 *PETPrep* can segment the brain into different brain regions and extract time activity curves from these regions.
 The ``--seg`` flag selects the segmentation method to use.
-Available options are ``gtm`` (default) whole-brain segmentation from FreeSurfer, ``brainstem``, ``wm`` (white matter), ``thalamicNuclei``, ``hippocampusAmygdala``, ``raphe``, and ``limbic``. Atlas-based segmentations can also be selected with ``--seg``; the atlas choices are ``HOCPA`` (harvard-oxford atlas), the Schaefer 2018 atlas variants listed in `Atlas Segmentation`_, and ``MASSP20`` (subcortical atlas). When an atlas is selected, *PETPrep* automatically adds the atlas template to ``--output-spaces`` and warps the atlas and its label file into anatomical space. For more information about the atlas choices, see the section `Atlas Segmentation`_.
+Available options are ``gtm`` (default) whole-brain segmentation from FreeSurfer, ``brainstem``, ``wm`` (white matter), ``aparcaseg`` (FreeSurfer ``aparc+aseg.mgz``), ``thalamicNuclei``, ``hippocampusAmygdala``, ``raphe``, and ``limbic``. Atlas-based segmentations can also be selected with ``--seg``; the atlas choices are ``HOCPA`` (harvard-oxford atlas), the Schaefer 2018 atlas variants listed in `Atlas Segmentation`_, and ``MASSP20`` (subcortical atlas). When an atlas is selected, *PETPrep* automatically adds the atlas template to ``--output-spaces`` and warps the atlas and its label file into anatomical space. For more information about the atlas choices, see the section `Atlas Segmentation`_.
 The ``gtm`` segmentation is a whole-brain segmentation that includes the
 cerebral cortex, subcortical structures, and cerebellum.
 
@@ -408,6 +408,7 @@ The available masks are and do not require ``--ref-mask-index`` to be specified:
 - ``semiovale``: White matter in the centrum semiovale (requires the ``--seg wm`` option).
 - ``neocortex``: Neocortical gray matter (requires the ``--seg gtm`` option).
 - ``thalamus``: Thalamic gray matter (requires the ``--seg gtm`` option).
+- ``cc``: Corpus callosum labels 251-255 (requires the ``--seg aparcaseg`` option).
 
 The presets are defined in ``petprep/data/reference_mask/config.json``.
 

--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -649,6 +649,7 @@ https://petprep.readthedocs.io/en/{currentv.base_version if is_release else 'lat
         'thalamicNuclei',
         'hippocampusAmygdala',
         'wm',
+        'aparcaseg',
         'raphe',
         'limbic',
         *sorted(atlas_config.keys()),

--- a/petprep/cli/tests/test_parser.py
+++ b/petprep/cli/tests/test_parser.py
@@ -733,6 +733,11 @@ def test_reference_mask_options(tmp_path, minimal_bids, monkeypatch, capsys):
     assert config.workflow.ref_mask_name == 'semiovale'
     _reset_config()
 
+    parse_args(args=base_args + ['--seg', 'aparcaseg', '--ref-mask-name', 'cc'])
+    assert config.workflow.seg == 'aparcaseg'
+    assert config.workflow.ref_mask_name == 'cc'
+    _reset_config()
+
 
 def test_reference_mask_validation_edge_cases(tmp_path, minimal_bids, monkeypatch, capsys):
     """Cover parser errors for unsupported masks with and without segmentation mappings."""

--- a/petprep/config.py
+++ b/petprep/config.py
@@ -626,7 +626,7 @@ class workflow(_Config):
     """Disable head-motion correction and keep data uncorrected."""
     seg = 'gtm'
     """Segmentation approach ('gtm', 'brainstem', 'thalamicNuclei',
-    'hippocampusAmygdala', 'wm', 'raphe', 'limbic')."""
+    'hippocampusAmygdala', 'wm', 'aparcaseg', 'raphe', 'limbic')."""
 
     pvc_tool: str | None = None
     """Tool used for partial volume correction."""

--- a/petprep/data/reference_mask/config.json
+++ b/petprep/data/reference_mask/config.json
@@ -39,5 +39,11 @@
       "target_volume_ml": 40,
       "gm_prob_threshold": 0
     }
+  },
+  "aparcaseg": {
+    "cc":
+    {
+      "refmask_indices": [251, 252, 253, 254, 255]
+    }
   }
 }

--- a/petprep/interfaces/segmentation.py
+++ b/petprep/interfaces/segmentation.py
@@ -381,9 +381,7 @@ class SegmentAparcAseg(SimpleInterface):
             Path(self.inputs.subjects_dir) / self.inputs.subject_id / 'mri' / 'aparc+aseg.mgz'
         )
         if not out_file.exists():
-            raise FileNotFoundError(
-                f'FreeSurfer aparc+aseg segmentation not found: {out_file}'
-            )
+            raise FileNotFoundError(f'FreeSurfer aparc+aseg segmentation not found: {out_file}')
 
         runtime.returncode = 0
         self._results['out_file'] = str(out_file)

--- a/petprep/interfaces/segmentation.py
+++ b/petprep/interfaces/segmentation.py
@@ -361,6 +361,35 @@ class SegmentWM(SimpleInterface):
         return proc.stdout, proc.stderr
 
 
+class SegmentAparcAsegInputSpec(BaseInterfaceInputSpec):
+    subjects_dir = Directory(exists=True, mandatory=True, desc='FreeSurfer subjects directory')
+    subject_id = traits.Str(mandatory=True, desc='Subject identifier')
+
+
+class SegmentAparcAsegOutputSpec(TraitedSpec):
+    out_file = File(exists=True, desc='FreeSurfer aparc+aseg segmentation')
+
+
+class SegmentAparcAseg(SimpleInterface):
+    """Expose the existing FreeSurfer ``aparc+aseg.mgz`` segmentation."""
+
+    input_spec = SegmentAparcAsegInputSpec
+    output_spec = SegmentAparcAsegOutputSpec
+
+    def _run_interface(self, runtime):
+        out_file = (
+            Path(self.inputs.subjects_dir) / self.inputs.subject_id / 'mri' / 'aparc+aseg.mgz'
+        )
+        if not out_file.exists():
+            raise FileNotFoundError(
+                f'FreeSurfer aparc+aseg segmentation not found: {out_file}'
+            )
+
+        runtime.returncode = 0
+        self._results['out_file'] = str(out_file)
+        return runtime
+
+
 class SegmentGTM(GTMSeg):
     """Run ``gtmseg`` unless outputs already exist."""
 

--- a/petprep/interfaces/tests/test_reference_mask.py
+++ b/petprep/interfaces/tests/test_reference_mask.py
@@ -5,6 +5,7 @@ import nibabel as nb
 import numpy as np
 from nipype.pipeline import engine as pe
 
+from ...data import load as load_data
 from ..reference_mask import ExtractRefRegion
 
 
@@ -147,3 +148,31 @@ def test_extract_refregion_gm_threshold(tmp_path):
     out = nb.load(res.outputs.refmask_file).get_fdata()
     assert out.sum() == 1
     assert out[2, 2, 2] == 1
+
+
+def test_extract_refregion_cc_from_aparcaseg_config(tmp_path):
+    data = np.zeros((5, 5, 5), dtype=np.uint8)
+    data[1, 1, 1] = 251
+    data[1, 1, 2] = 252
+    data[1, 1, 3] = 253
+    data[1, 2, 1] = 254
+    data[1, 2, 2] = 255
+    data[2, 2, 2] = 250
+    seg_file = tmp_path / 'aparc+aseg.nii.gz'
+    nb.Nifti1Image(data, np.eye(4)).to_filename(seg_file)
+
+    node = pe.Node(
+        ExtractRefRegion(
+            seg_file=str(seg_file),
+            config_file=str(load_data('reference_mask/config.json')),
+            segmentation_type='aparcaseg',
+            region_name='cc',
+        ),
+        name='er_cc',
+        base_dir=str(tmp_path),
+    )
+    res = node.run()
+    out = nb.load(res.outputs.refmask_file).get_fdata()
+
+    assert out.sum() == 5
+    assert out[2, 2, 2] == 0

--- a/petprep/interfaces/tests/test_segmentation_interface.py
+++ b/petprep/interfaces/tests/test_segmentation_interface.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from ... import config
 from ..segmentation import (
     MRISclimbicSeg,
+    SegmentAparcAseg,
     SegmentBS,
     SegmentGTM,
     SegmentHA_T1,
@@ -80,6 +81,19 @@ def test_segmentwm_stdout_stderr(monkeypatch, tmp_path):
     res = seg.run()
     assert res.outputs.stdout == 'wm out'
     assert res.outputs.stderr == 'wm err'
+
+
+def test_segment_aparcaseg_uses_existing_file(tmp_path):
+    subj_dir = tmp_path / 'sub-01' / 'mri'
+    subj_dir.mkdir(parents=True)
+    aparcaseg = subj_dir / 'aparc+aseg.mgz'
+    aparcaseg.write_text('')
+
+    seg = SegmentAparcAseg(subjects_dir=str(tmp_path), subject_id='sub-01')
+    res = seg.run()
+
+    assert res.runtime.returncode == 0
+    assert Path(res.outputs.out_file) == aparcaseg
 
 
 def test_set_freesurfer_seed_runtime():

--- a/petprep/workflows/pet/segmentation.py
+++ b/petprep/workflows/pet/segmentation.py
@@ -16,6 +16,7 @@ from ...interfaces import DerivativesDataSink
 from ...interfaces.bids import BIDSURI
 from ...interfaces.segmentation import (
     MRISclimbicSeg,
+    SegmentAparcAseg,
     SegmentBS,
     SegmentGTM,
     SegmentHA_T1,
@@ -95,6 +96,11 @@ SEGMENTATIONS = {
     'wm': {
         'interface': SegmentWM,
         'desc': 'whiteMatter',
+        'inputs': [('subjects_dir', 'subjects_dir'), ('subject_id', 'subject_id')],
+    },
+    'aparcaseg': {
+        'interface': SegmentAparcAseg,
+        'desc': 'aparcaseg',
         'inputs': [('subjects_dir', 'subjects_dir'), ('subject_id', 'subject_id')],
     },
     'raphe': {

--- a/petprep/workflows/pet/tests/test_segmentation.py
+++ b/petprep/workflows/pet/tests/test_segmentation.py
@@ -21,6 +21,12 @@ def test_segmentation_node_selection():
         assert 'create_wm_dsegtsv' in names_wm
         assert 'create_wm_morphtsv' in names_wm
 
+        wf_aparcaseg = init_segmentation_wf('aparcaseg')
+        names_aparcaseg = [n.name for n in wf_aparcaseg._get_all_nodes()]
+        assert 'segstats_aparcaseg' in names_aparcaseg
+        assert 'create_aparcaseg_dsegtsv' in names_aparcaseg
+        assert 'create_aparcaseg_morphtsv' in names_aparcaseg
+
 
 def test_merge_ha_labels(tmp_path):
     """Merged volume should match input geometry."""


### PR DESCRIPTION
This PR addresses issue #313, by adding --seg aparcaseg support using FreeSurfer aparc+aseg.mgz, wired through the existing segmentation workflow similarly to wm.

Adds predefined --ref-mask-name cc for corpus callosum labels 251-255.

Updates docs and adds parser, workflow, interface, and reference-mask tests.