### PR TITLE
MAINT: fix petprep-docker help under Python 3.14

### DIFF
--- a/wrapper/src/petprep_docker/__main__.py
+++ b/wrapper/src/petprep_docker/__main__.py
@@ -133,6 +133,8 @@ def check_memory(image):
 
 
 def merge_help(wrapper_help, target_help):
+    ansi_re = re.compile(r'\x1b\[[0-?]*[ -/]*[@-~]')
+
     def _get_posargs(usage):
         """
         Extract positional arguments from usage string.
@@ -158,8 +160,8 @@ def merge_help(wrapper_help, target_help):
     flag_re = re.compile(r'\[--?([\w-]+)[ \]]')
 
     # Normalize to Unix-style line breaks
-    w_help = wrapper_help.rstrip().replace('\r', '')
-    t_help = target_help.rstrip().replace('\r', '')
+    w_help = ansi_re.sub('', wrapper_help.rstrip().replace('\r', ''))
+    t_help = ansi_re.sub('', target_help.rstrip().replace('\r', ''))
 
     w_usage, w_details = w_help.split('\n\n', 1)
     w_groups = w_details.split('\n\n')

--- a/wrapper/src/tests/test_docker_parser.py
+++ b/wrapper/src/tests/test_docker_parser.py
@@ -9,6 +9,20 @@ def test_docker_get_parser():
     assert parser is not None
 
 
+def test_merge_help_strips_ansi_codes(monkeypatch, tmp_path):
+    monkeypatch.setenv('MPLCONFIGDIR', str(tmp_path / 'mplconfig'))
+
+    from petprep.cli.parser import _build_parser
+
+    wrapper_help = ppd.get_parser().format_help()
+    wrapper_help = wrapper_help.replace('[-h]', '[\x1b[1m-h\x1b[0m]', 1)
+    wrapper_help = wrapper_help.replace('[--version]', '[\x1b[1m--version\x1b[0m]', 1)
+
+    merged = ppd.merge_help(wrapper_help, _build_parser().format_help())
+
+    assert merged.startswith('usage:')
+
+
 def test_docker_main_help(monkeypatch, capsys):
     monkeypatch.setattr(ppd, 'check_docker', lambda: 1)
     monkeypatch.setattr(ppd, 'check_image', lambda img: True)


### PR DESCRIPTION
This fixes a petprep-docker --help failure on Python 3.14 caused by ANSI-colored argparse help output. The wrapper merges its own help text with PETPrep’s help text using regex parsing, and color escape sequences could prevent the expected -h and --version flags from being detected.

The update strips ANSI escape codes from both wrapper and target help text before parsing, and adds a regression test covering colorized help output.