### PR TITLE
FIX: Auto-enable fixed skull-strip seed when random seed is set

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -37,6 +37,15 @@ Example: ::
 Further information about BIDS and BIDS-Apps can be found at the
 `NiPreps portal <https://www.nipreps.org/apps/framework/>`__.
 
+Reproducible runs
+-----------------
+Use :option:`--random-seed` to initialize PETPrep's workflow-level random
+number generators. When this option is provided, PETPrep also enables
+:option:`--skull-strip-fixed-seed` so the ANTs skull-stripping step does not
+introduce an independent source of run-to-run randomness. For the most
+reproducible execution, pair :option:`--random-seed` with
+``--omp-nthreads 1`` and ``--nprocs 1``.
+
 Combining multiple PET runs within a session
 --------------------------------------------
 Some PET datasets include multiple ``run`` acquisitions for the same

--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -85,7 +85,7 @@ def _build_parser(**kwargs):
     class RandomSeedAction(Action):
         def __call__(self, parser, namespace, values, option_string=None):
             setattr(namespace, self.dest, values)
-            setattr(namespace, 'skull_strip_fixed_seed', True)
+            namespace.skull_strip_fixed_seed = True
 
     def _path_exists(path, parser):
         """Ensure a given path exists."""

--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -82,6 +82,11 @@ def _build_parser(**kwargs):
                 d[name] = loc
             setattr(namespace, self.dest, d)
 
+    class RandomSeedAction(Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            setattr(namespace, self.dest, values)
+            setattr(namespace, 'skull_strip_fixed_seed', True)
+
     def _path_exists(path, parser):
         """Ensure a given path exists."""
         if path is None or not Path(path).exists():
@@ -450,10 +455,10 @@ https://petprep.readthedocs.io/en/{currentv.base_version if is_release else 'lat
     g_conf.add_argument(
         '--random-seed',
         dest='_random_seed',
-        action='store',
+        action=RandomSeedAction,
         type=int,
         default=None,
-        help='Initialize the random seed for the workflow',
+        help='Initialize the random seed for the workflow and fix the skull-stripping seed',
     )
 
     g_outputs = parser.add_argument_group('Options for modulating outputs')
@@ -559,9 +564,9 @@ https://petprep.readthedocs.io/en/{currentv.base_version if is_release else 'lat
     g_ants.add_argument(
         '--skull-strip-fixed-seed',
         action='store_true',
-        help='Do not use a random seed for skull-stripping - will ensure '
-        'run-to-run replicability when used with --omp-nthreads 1 and '
-        'matching --random-seed <int>',
+        help='Fix the skull-stripping seed. This is enabled automatically with '
+        '--random-seed and helps ensure run-to-run replicability when used with '
+        '--omp-nthreads 1.',
     )
     g_ants.add_argument(
         '--skull-strip-t1w',

--- a/petprep/cli/tests/test_parser.py
+++ b/petprep/cli/tests/test_parser.py
@@ -71,6 +71,19 @@ def test_parser_valid(tmp_path, args):
     assert opts.bids_dir == datapath
 
 
+def test_random_seed_enables_skull_strip_fixed_seed(tmp_path):
+    """Ensure --random-seed pins skull-stripping randomness."""
+    datapath = tmp_path / 'data'
+    datapath.mkdir()
+
+    opts = _build_parser().parse_args(
+        [str(datapath), 'out/', 'participant', '--random-seed', '42']
+    )
+
+    assert opts._random_seed == 42
+    assert opts.skull_strip_fixed_seed is True
+
+
 @pytest.mark.parametrize(
     ('argval', 'gb'),
     [


### PR DESCRIPTION
This PR addresses issue #315, by automatically enabling --skull-strip-fixed-seed whenever --random-seed is explicitly provided, so skull stripping no longer remains an independent source of run-to-run randomness.

This also updates the CLI help text, adds a short usage note about reproducible runs, and includes a parser regression test.