### PR TITLE
WIP: Add data-driven memory safeguards for PET head motion correction

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -230,12 +230,17 @@ used.
 
 For PET series with many selected frames or large spatial dimensions, *PETPrep*
 estimates the memory required by ``mri_robust_template`` after applying
-:option:`--hmc-start-time`. If the estimate is high, or if it would consume a
-large fraction of the requested :option:`--mem` budget, *PETPrep* automatically
-uses FreeSurfer's ``--subsample 200`` option and fixes the selected initial
-frame, disabling robust-template iterations. This keeps the workflow as a
-single robust-template step while reducing peak memory pressure for long or
-high-resolution dynamic PET acquisitions.
+:option:`--hmc-start-time`. If the data-driven estimate is high, *PETPrep*
+automatically fixes the selected initial frame, disabling robust-template
+iterations, and uses a FreeSurfer ``--subsample`` threshold when the spatial
+dimensions support safe subsampling. The threshold is at most 200 and is lowered
+below the smallest spatial dimension when needed so FreeSurfer's all-axis
+subsampling condition can take effect, but is not lowered below 150 voxels. This
+keeps the workflow as a single robust-template step while reducing peak memory
+pressure for long or high-resolution dynamic PET acquisitions without forcing a
+very coarse registration grid. The estimate, selected frame count and reason for
+the decision are recorded in the workflow log; the chosen HMC settings are
+reflected in the workflow boilerplate.
 
 When motion correction is undesirable, use :option:`--hmc-off` to disable head motion
 correction entirely and keep the data unmodified apart from downstream

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -230,17 +230,20 @@ used.
 
 For PET series with many selected frames or large spatial dimensions, *PETPrep*
 estimates the memory required by ``mri_robust_template`` after applying
-:option:`--hmc-start-time`. If the data-driven estimate is high, *PETPrep*
-automatically fixes the selected initial frame, disabling robust-template
-iterations, and uses a FreeSurfer ``--subsample`` threshold when the spatial
-dimensions support safe subsampling. The threshold is at most 200 and is lowered
-below the smallest spatial dimension when needed so FreeSurfer's all-axis
-subsampling condition can take effect, but is not lowered below 150 voxels. This
-keeps the workflow as a single robust-template step while reducing peak memory
-pressure for long or high-resolution dynamic PET acquisitions without forcing a
-very coarse registration grid. The estimate, selected frame count and reason for
-the decision are recorded in the workflow log; the chosen HMC settings are
-reflected in the workflow boilerplate.
+:option:`--hmc-start-time`. With the default :option:`--hmc-memory-policy`
+``auto``, if the data-driven estimate is high, *PETPrep* automatically fixes the
+selected initial frame, disabling robust-template iterations, and uses a
+FreeSurfer ``--subsample`` threshold when the spatial dimensions support safe
+subsampling. The threshold is at most 200 and is lowered below the smallest
+spatial dimension when needed so FreeSurfer's all-axis subsampling condition can
+take effect, but is not lowered below 150 voxels. This keeps the workflow as a
+single robust-template step while reducing peak memory pressure for long or
+high-resolution dynamic PET acquisitions without forcing a very coarse
+registration grid. The estimate, selected frame count and reason for the
+decision are recorded in the workflow log; the chosen HMC settings are reflected
+in the workflow boilerplate. Use :option:`--hmc-memory-policy` ``off`` to disable
+these automatic memory safeguards and run HMC with only the explicitly requested
+``mri_robust_template`` settings.
 
 When motion correction is undesirable, use :option:`--hmc-off` to disable head motion
 correction entirely and keep the data unmodified apart from downstream
@@ -250,6 +253,7 @@ Examples: ::
 
     $ petprep /data/bids_root /out participant --hmc-fwhm 8 --hmc-start-time 60
     $ petprep /data/bids_root /out participant --hmc-init-frame 10 --hmc-init-frame-fix
+    $ petprep /data/bids_root /out participant --hmc-memory-policy off
     $ petprep /data/bids_root /out participant --hmc-off
 
 

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -410,13 +410,15 @@ reduce runtime. A 10 mm FWHM Gaussian is applied and estimation begins at
 120 s unless otherwise specified.
 
 For long or high-resolution series, PETPrep estimates robust-template memory
-from the selected frames. High-risk HMC runs automatically use fixed
-initial-frame registration and, when spatial dimensions support safe
-subsampling, a dynamic FreeSurfer ``--subsample`` threshold of at most 200. The
-threshold is lowered below the smallest spatial dimension when needed so
-FreeSurfer's all-axis subsampling condition can take effect, but is not lowered
-below 150 voxels. This decision is data-driven and is recorded in the workflow
-log; the selected HMC settings are reflected in the workflow boilerplate.
+from the selected frames. With the default :option:`--hmc-memory-policy` ``auto``,
+high-risk HMC runs automatically use fixed initial-frame registration and, when
+spatial dimensions support safe subsampling, a dynamic FreeSurfer ``--subsample``
+threshold of at most 200. The threshold is lowered below the smallest spatial
+dimension when needed so FreeSurfer's all-axis subsampling condition can take
+effect, but is not lowered below 150 voxels. This decision is data-driven and is
+recorded in the workflow log; the selected HMC settings are reflected in the
+workflow boilerplate. Use :option:`--hmc-memory-policy` ``off`` to disable these
+automatic memory safeguards.
 
 Pre-processed PET in native space
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -408,11 +408,15 @@ explicit zero-based frame index can be provided with
 frame fixed during robust template estimation and disables iterations to
 reduce runtime. A 10 mm FWHM Gaussian is applied and estimation begins at
 120 s unless otherwise specified.
+
 For long or high-resolution series, PETPrep estimates robust-template memory
-from the selected frames and compares the estimate with the requested
-:option:`--mem` budget when available. High-risk HMC runs automatically use
-FreeSurfer's ``--subsample 200`` setting and fixed initial-frame registration
-to lower peak memory use.
+from the selected frames. High-risk HMC runs automatically use fixed
+initial-frame registration and, when spatial dimensions support safe
+subsampling, a dynamic FreeSurfer ``--subsample`` threshold of at most 200. The
+threshold is lowered below the smallest spatial dimension when needed so
+FreeSurfer's all-axis subsampling condition can take effect, but is not lowered
+below 150 voxels. This decision is data-driven and is recorded in the workflow
+log; the selected HMC settings are reflected in the workflow boilerplate.
 
 Pre-processed PET in native space
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -668,7 +668,7 @@ https://petprep.readthedocs.io/en/{currentv.base_version if is_release else 'lat
         default='auto',
         help=(
             "Policy for automatic HMC memory safeguards. 'auto' estimates robust-template "
-            "memory from the PET data and enables fixed-frame/subsample safeguards for "
+            'memory from the PET data and enables fixed-frame/subsample safeguards for '
             "high-risk scans; 'off' disables these automatic safeguards."
         ),
     )

--- a/petprep/cli/parser.py
+++ b/petprep/cli/parser.py
@@ -663,6 +663,16 @@ https://petprep.readthedocs.io/en/{currentv.base_version if is_release else 'lat
         help=('Keep the chosen initial reference frame fixed during head-motion estimation.'),
     )
     g_hmc.add_argument(
+        '--hmc-memory-policy',
+        choices=['auto', 'off'],
+        default='auto',
+        help=(
+            "Policy for automatic HMC memory safeguards. 'auto' estimates robust-template "
+            "memory from the PET data and enables fixed-frame/subsample safeguards for "
+            "high-risk scans; 'off' disables these automatic safeguards."
+        ),
+    )
+    g_hmc.add_argument(
         '--hmc-off',
         dest='hmc_off',
         action='store_true',

--- a/petprep/cli/tests/test_parser.py
+++ b/petprep/cli/tests/test_parser.py
@@ -911,3 +911,22 @@ def test_hmc_off_flag(tmp_path):
 
     opts = parser.parse_args(base_args + ['--hmc-off'])
     assert opts.hmc_off is True
+
+
+def test_hmc_memory_policy_parsing(tmp_path):
+    """Ensure HMC memory policy choices are parsed correctly."""
+    datapath = tmp_path / 'data'
+    outpath = tmp_path / 'out'
+    datapath.mkdir()
+
+    parser = _build_parser()
+    base_args = [str(datapath), str(outpath), 'participant']
+
+    opts = parser.parse_args(base_args)
+    assert opts.hmc_memory_policy == 'auto'
+
+    opts = parser.parse_args(base_args + ['--hmc-memory-policy', 'off'])
+    assert opts.hmc_memory_policy == 'off'
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(base_args + ['--hmc-memory-policy', 'aggressive'])

--- a/petprep/config.py
+++ b/petprep/config.py
@@ -634,6 +634,8 @@ class workflow(_Config):
     """Index of initial frame for head-motion estimation ('auto' selects highest uptake)."""
     hmc_fix_frame: bool = False
     """Whether to fix the reference frame during head-motion estimation."""
+    hmc_memory_policy: str = 'auto'
+    """Policy for automatic HMC memory safeguards ('auto' or 'off')."""
     hmc_off: bool = False
     """Disable head-motion correction and keep data uncorrected."""
     seg = 'gtm'

--- a/petprep/workflows/pet/fit.py
+++ b/petprep/workflows/pet/fit.py
@@ -800,34 +800,49 @@ def init_pet_fit_wf(
         config.loggers.workflow.info(
             'PET Stage 1: Adding motion correction workflow and petref estimation'
         )
-        hmc_policy = plan_hmc_resource_policy(
-            pet_file,
-            start_time=config.workflow.hmc_start_time,
-            frame_durations=frame_durations,
-            frame_start_times=frame_start_times,
-            fixed_frame=config.workflow.hmc_fix_frame,
-        )
-        if hmc_policy['auto_limited']:
-            subsample_msg = (
-                f' with --subsample {hmc_policy["subsample_threshold"]}'
-                if hmc_policy['subsample_threshold'] is not None
-                else ''
+        if config.workflow.hmc_memory_policy == 'auto':
+            hmc_policy = plan_hmc_resource_policy(
+                pet_file,
+                start_time=config.workflow.hmc_start_time,
+                frame_durations=frame_durations,
+                frame_start_times=frame_start_times,
+                fixed_frame=config.workflow.hmc_fix_frame,
             )
-            config.loggers.workflow.warning(
-                'PET HMC data-driven memory policy selected high-memory settings: '
-                f'estimated {hmc_policy["estimated_memory_gb"]:.2f} GB for '
-                f'{hmc_policy["selected_frames"]}/{hmc_policy["total_frames"]} selected '
-                f'frames ({hmc_policy["reason"]}); planned estimate '
-                f'{hmc_policy["planned_memory_gb"]:.2f} GB{subsample_msg} '
-                'and fixed initial-frame registration '
-                'for mri_robust_template.'
+            if hmc_policy['auto_limited']:
+                subsample_msg = (
+                    f' with --subsample {hmc_policy["subsample_threshold"]}'
+                    if hmc_policy['subsample_threshold'] is not None
+                    else ''
+                )
+                config.loggers.workflow.warning(
+                    'PET HMC data-driven memory policy selected high-memory settings: '
+                    f'estimated {hmc_policy["estimated_memory_gb"]:.2f} GB for '
+                    f'{hmc_policy["selected_frames"]}/{hmc_policy["total_frames"]} selected '
+                    f'frames ({hmc_policy["reason"]}); planned estimate '
+                    f'{hmc_policy["planned_memory_gb"]:.2f} GB{subsample_msg} '
+                    'and fixed initial-frame registration '
+                    'for mri_robust_template.'
+                )
+            else:
+                config.loggers.workflow.info(
+                    'PET HMC data-driven memory policy selected standard settings: '
+                    f'estimated {hmc_policy["estimated_memory_gb"]:.2f} GB '
+                    f'for {hmc_policy["selected_frames"]}/{hmc_policy["total_frames"]} '
+                    'selected frames.'
+                )
+        elif config.workflow.hmc_memory_policy == 'off':
+            hmc_policy = {
+                'planned_memory_gb': mem_gb['filesize'],
+                'fixed_frame': config.workflow.hmc_fix_frame,
+                'subsample_threshold': None,
+            }
+            config.loggers.workflow.info(
+                'PET HMC memory policy disabled (--hmc-memory-policy off); '
+                'using configured mri_robust_template settings.'
             )
         else:
-            config.loggers.workflow.info(
-                'PET HMC data-driven memory policy selected standard settings: '
-                f'estimated {hmc_policy["estimated_memory_gb"]:.2f} GB '
-                f'for {hmc_policy["selected_frames"]}/{hmc_policy["total_frames"]} '
-                'selected frames.'
+            raise ValueError(
+                f"Unsupported HMC memory policy: {config.workflow.hmc_memory_policy!r}"
             )
 
         pet_hmc_wf = init_pet_hmc_wf(
@@ -841,6 +856,7 @@ def init_pet_fit_wf(
             initial_frame=config.workflow.hmc_init_frame,
             fixed_frame=hmc_policy['fixed_frame'],
             subsample_threshold=hmc_policy['subsample_threshold'],
+            memory_policy=config.workflow.hmc_memory_policy,
         )
 
         ds_hmc_wf = init_ds_hmc_wf(

--- a/petprep/workflows/pet/fit.py
+++ b/petprep/workflows/pet/fit.py
@@ -842,7 +842,7 @@ def init_pet_fit_wf(
             )
         else:
             raise ValueError(
-                f"Unsupported HMC memory policy: {config.workflow.hmc_memory_policy!r}"
+                f'Unsupported HMC memory policy: {config.workflow.hmc_memory_policy!r}'
             )
 
         pet_hmc_wf = init_pet_hmc_wf(

--- a/petprep/workflows/pet/fit.py
+++ b/petprep/workflows/pet/fit.py
@@ -42,7 +42,7 @@ from ...utils.misc import estimate_pet_mem_usage
 
 # PET workflows
 from .confounds import _binary_union, _smooth_binarize
-from .hmc import init_pet_hmc_wf
+from .hmc import init_pet_hmc_wf, plan_hmc_resource_policy
 from .outputs import (
     init_ds_hmc_wf,
     init_ds_petmask_wf,
@@ -832,14 +832,15 @@ def init_pet_fit_wf(
 
         pet_hmc_wf = init_pet_hmc_wf(
             name='pet_hmc_wf',
-            mem_gb=mem_gb['filesize'],
+            mem_gb=max(mem_gb['filesize'], hmc_policy['planned_memory_gb']),
             omp_nthreads=omp_nthreads,
             fwhm=config.workflow.hmc_fwhm,
             start_time=config.workflow.hmc_start_time,
             frame_durations=frame_durations,
             frame_start_times=frame_start_times,
             initial_frame=config.workflow.hmc_init_frame,
-            fixed_frame=config.workflow.hmc_fix_frame,
+            fixed_frame=hmc_policy['fixed_frame'],
+            subsample_threshold=hmc_policy['subsample_threshold'],
         )
 
         ds_hmc_wf = init_ds_hmc_wf(

--- a/petprep/workflows/pet/fit.py
+++ b/petprep/workflows/pet/fit.py
@@ -805,20 +805,27 @@ def init_pet_fit_wf(
             start_time=config.workflow.hmc_start_time,
             frame_durations=frame_durations,
             frame_start_times=frame_start_times,
-            requested_memory_gb=config.nipype.memory_gb,
             fixed_frame=config.workflow.hmc_fix_frame,
         )
         if hmc_policy['auto_limited']:
+            subsample_msg = (
+                f' with --subsample {hmc_policy["subsample_threshold"]}'
+                if hmc_policy['subsample_threshold'] is not None
+                else ''
+            )
             config.loggers.workflow.warning(
-                f'PET HMC memory estimate is high ({hmc_policy["estimated_memory_gb"]:.2f} GB '
-                f'for {hmc_policy["selected_frames"]}/{hmc_policy["total_frames"]} selected '
-                f'frames; {hmc_policy["reason"]}). Using --subsample '
-                f'{hmc_policy["subsample_threshold"]} and fixed initial-frame registration '
+                'PET HMC data-driven memory policy selected high-memory settings: '
+                f'estimated {hmc_policy["estimated_memory_gb"]:.2f} GB for '
+                f'{hmc_policy["selected_frames"]}/{hmc_policy["total_frames"]} selected '
+                f'frames ({hmc_policy["reason"]}); planned estimate '
+                f'{hmc_policy["planned_memory_gb"]:.2f} GB{subsample_msg} '
+                'and fixed initial-frame registration '
                 'for mri_robust_template.'
             )
         else:
-            config.loggers.workflow.debug(
-                f'PET HMC memory estimate: {hmc_policy["estimated_memory_gb"]:.2f} GB '
+            config.loggers.workflow.info(
+                'PET HMC data-driven memory policy selected standard settings: '
+                f'estimated {hmc_policy["estimated_memory_gb"]:.2f} GB '
                 f'for {hmc_policy["selected_frames"]}/{hmc_policy["total_frames"]} '
                 'selected frames.'
             )

--- a/petprep/workflows/pet/hmc.py
+++ b/petprep/workflows/pet/hmc.py
@@ -48,9 +48,9 @@ from nipype.interfaces.utility import Select
 from nipype.pipeline import engine as pe
 
 HMC_AUTO_SUBSAMPLE_THRESHOLD = 200
+HMC_MIN_SUBSAMPLE_THRESHOLD = 150
 HMC_HIGH_FRAME_COUNT = 40
 HMC_HIGH_MEMORY_GB = 8.0
-HMC_MEMORY_BUDGET_FRACTION = 0.75
 
 
 def get_start_frame(
@@ -140,6 +140,18 @@ def _estimate_hmc_gb(
     return hmc_gb, frame_gb
 
 
+def _select_hmc_subsample_threshold(
+    min_spatial_dim: int,
+    *,
+    preferred_threshold: int = HMC_AUTO_SUBSAMPLE_THRESHOLD,
+    minimum_threshold: int = HMC_MIN_SUBSAMPLE_THRESHOLD,
+) -> int | None:
+    """Choose a threshold that can activate FreeSurfer's all-axis subsampling."""
+    if min_spatial_dim <= minimum_threshold:
+        return None
+    return min(preferred_threshold, min_spatial_dim - 1)
+
+
 def estimate_hmc_mem_usage(
     pet_file: str,
     *,
@@ -169,6 +181,7 @@ def estimate_hmc_mem_usage(
     return {
         'estimate': hmc_gb,
         'frame': frame_gb,
+        'min_spatial_dim': int(min(img.shape[:3])),
         'selected_frames': selected_frames,
         'start_frame': start_idx,
         'total_frames': n_total_frames,
@@ -181,11 +194,10 @@ def plan_hmc_resource_policy(
     start_time: float = 120.0,
     frame_durations: Sequence[float] | None = None,
     frame_start_times: Sequence[float] | None = None,
-    requested_memory_gb: float | None = None,
     fixed_frame: bool = False,
     subsample_threshold: int = HMC_AUTO_SUBSAMPLE_THRESHOLD,
 ) -> dict[str, float | int | bool | str | None]:
-    """Plan memory-saving options for robust-template HMC."""
+    """Plan data-driven memory-saving options for robust-template HMC."""
     estimate = estimate_hmc_mem_usage(
         pet_file,
         start_time=start_time,
@@ -198,17 +210,16 @@ def plan_hmc_resource_policy(
         reasons.append(f'{estimate["selected_frames"]} selected frames')
     if estimate['estimate'] >= HMC_HIGH_MEMORY_GB:
         reasons.append(f'estimated HMC memory {estimate["estimate"]:.2f} GB')
-    if (
-        requested_memory_gb
-        and estimate['estimate'] >= HMC_MEMORY_BUDGET_FRACTION * requested_memory_gb
-    ):
-        reasons.append(
-            f'estimated HMC memory is at least '
-            f'{int(HMC_MEMORY_BUDGET_FRACTION * 100)}% of requested memory'
-        )
 
     auto_limit_memory = bool(reasons)
-    planned_subsample = subsample_threshold if auto_limit_memory else None
+    planned_subsample = (
+        _select_hmc_subsample_threshold(
+            estimate['min_spatial_dim'],
+            preferred_threshold=subsample_threshold,
+        )
+        if auto_limit_memory
+        else None
+    )
     planned_estimate = estimate
     if planned_subsample is not None:
         planned_estimate = estimate_hmc_mem_usage(
@@ -353,6 +364,17 @@ Head-motion parameters with respect to the PET reference
 (transformation matrices, and six corresponding rotation and translation
 parameters) are estimated before any spatiotemporal filtering using
 FreeSurfer's ``mri_robust_template``.
+"""
+    if subsample_threshold is not None:
+        workflow.__desc__ += f"""\
+High-memory PET HMC settings were selected from data characteristics, and
+FreeSurfer's ``mri_robust_template`` was run with
+``--subsample {int(subsample_threshold)}``.
+"""
+    if fixed_frame:
+        workflow.__desc__ += """\
+The selected initial frame was fixed during robust-template estimation,
+disabling robust-template iterations.
 """
 
     inputnode = pe.Node(

--- a/petprep/workflows/pet/hmc.py
+++ b/petprep/workflows/pet/hmc.py
@@ -286,6 +286,7 @@ def init_pet_hmc_wf(
     initial_frame: int | str | None = 'auto',
     fixed_frame: bool = False,
     subsample_threshold: int | None = None,
+    memory_policy: str = 'auto',
     name: str = 'pet_hmc_wf',
 ):
     r"""
@@ -336,6 +337,8 @@ def init_pet_hmc_wf(
     subsample_threshold : :obj:`int` or ``None``
         FreeSurfer ``mri_robust_template --subsample`` threshold. If ``None``,
         robust-template subsampling is not requested.
+    memory_policy : {'auto', 'off'}
+        Whether automatic HMC memory safeguards were enabled for this workflow.
     name : :obj:`str`
         Name of workflow (default: ``pet_hmc_wf``)
 
@@ -364,6 +367,11 @@ Head-motion parameters with respect to the PET reference
 (transformation matrices, and six corresponding rotation and translation
 parameters) are estimated before any spatiotemporal filtering using
 FreeSurfer's ``mri_robust_template``.
+"""
+    if memory_policy == 'off':
+        workflow.__desc__ += """\
+Automatic HMC memory safeguards were disabled with
+:option:`--hmc-memory-policy off`.
 """
     if subsample_threshold is not None:
         workflow.__desc__ += f"""\

--- a/petprep/workflows/pet/hmc.py
+++ b/petprep/workflows/pet/hmc.py
@@ -285,6 +285,7 @@ def init_pet_hmc_wf(
     frame_start_times: Sequence[float] | None = None,
     initial_frame: int | str | None = 'auto',
     fixed_frame: bool = False,
+    subsample_threshold: int | None = None,
     name: str = 'pet_hmc_wf',
 ):
     r"""
@@ -332,6 +333,9 @@ def init_pet_hmc_wf(
         Whether to keep the initial time point fixed during robust template
         estimation (``fs.RobustTemplate``'s ``fixtp`` parameter). If ``True``,
         iterations are skipped to reduce runtime.
+    subsample_threshold : :obj:`int` or ``None``
+        FreeSurfer ``mri_robust_template --subsample`` threshold. If ``None``,
+        robust-template subsampling is not requested.
     name : :obj:`str`
         Name of workflow (default: ``pet_hmc_wf``)
 
@@ -454,17 +458,22 @@ disabling robust-template iterations.
         )
 
     # Motion estimation
+    robust_template_kwargs = {
+        'auto_detect_sensitivity': True,
+        'intensity_scaling': True,
+        'average_metric': 'mean',
+        'args': '--cras',
+        'num_threads': omp_nthreads,
+        'fixed_timepoint': fixed_frame,
+        'no_iteration': fixed_frame,
+    }
+    if subsample_threshold is not None:
+        robust_template_kwargs['subsample_threshold'] = int(subsample_threshold)
+
     robust_template = pe.Node(
-        fs.RobustTemplate(
-            auto_detect_sensitivity=True,
-            intensity_scaling=True,
-            average_metric='mean',
-            args='--cras',
-            num_threads=omp_nthreads,
-            fixed_timepoint=fixed_frame,
-            no_iteration=fixed_frame,
-        ),
+        fs.RobustTemplate(**robust_template_kwargs),
         name='est_robust_hmc',
+        mem_gb=max(float(mem_gb), 0.01),
     )
     if not auto_init_frame:
         robust_template.inputs.initial_timepoint = int(initial_frame) + 1

--- a/petprep/workflows/pet/hmc.py
+++ b/petprep/workflows/pet/hmc.py
@@ -50,7 +50,7 @@ from nipype.pipeline import engine as pe
 HMC_AUTO_SUBSAMPLE_THRESHOLD = 200
 HMC_MIN_SUBSAMPLE_THRESHOLD = 150
 HMC_HIGH_FRAME_COUNT = 40
-HMC_HIGH_MEMORY_GB = 8.0
+HMC_HIGH_MEMORY_GB = 24.0
 
 
 def get_start_frame(

--- a/petprep/workflows/pet/hmc.py
+++ b/petprep/workflows/pet/hmc.py
@@ -50,7 +50,7 @@ from nipype.pipeline import engine as pe
 HMC_AUTO_SUBSAMPLE_THRESHOLD = 200
 HMC_MIN_SUBSAMPLE_THRESHOLD = 150
 HMC_HIGH_FRAME_COUNT = 40
-HMC_HIGH_MEMORY_GB = 24.0
+HMC_HIGH_MEMORY_GB = 32.0
 
 
 def get_start_frame(

--- a/petprep/workflows/pet/tests/test_fit.py
+++ b/petprep/workflows/pet/tests/test_fit.py
@@ -576,6 +576,47 @@ def test_pet_fit_logs_high_memory_hmc_policy(
         assert 'with --subsample' not in warning
 
 
+def test_pet_fit_hmc_memory_policy_off_disables_auto_safeguards(
+    bids_root: Path,
+    monkeypatch,
+):
+    """``--hmc-memory-policy off`` should leave HMC settings user-controlled."""
+    pet_series = [str(bids_root / 'sub-01' / 'pet' / 'sub-01_task-rest_run-1_pet.nii.gz')]
+    img = nb.Nifti1Image(np.zeros((5, 5, 5, 4), dtype=np.float32), np.eye(4))
+    for path in pet_series:
+        img.to_filename(path)
+        Path(path).with_suffix('').with_suffix('.json').write_text(
+            '{"FrameTimesStart": [0, 1, 2, 3], "FrameDuration": [1, 1, 1, 1]}'
+        )
+
+    def _unexpected_plan_hmc_resource_policy(*_args, **_kwargs):
+        raise AssertionError('memory policy planner should not run when disabled')
+
+    monkeypatch.setattr(pet_fit, 'plan_hmc_resource_policy', _unexpected_plan_hmc_resource_policy)
+
+    messages = []
+    with mock_config(bids_dir=bids_root):
+        monkeypatch.setattr(
+            config.loggers.workflow,
+            'info',
+            lambda message, *_args, **_kwargs: messages.append(message),
+        )
+        config.workflow.hmc_memory_policy = 'off'
+        config.workflow.hmc_off = False
+        config.workflow.hmc_fix_frame = False
+        config.workflow.petref = 'template'
+        wf = init_pet_fit_wf(pet_series=pet_series, precomputed={}, omp_nthreads=1)
+
+    robust_node = next(node for node in wf._get_all_nodes() if node.name == 'est_robust_hmc')
+    hmc_wf = wf.get_node('pet_hmc_wf')
+
+    assert robust_node.inputs.fixed_timepoint is False
+    assert robust_node.inputs.no_iteration is False
+    assert robust_node.inputs.subsample_threshold is Undefined
+    assert '--hmc-memory-policy off' in hmc_wf.__desc__
+    assert any('PET HMC memory policy disabled' in message for message in messages)
+
+
 def test_pet_fit_robust_registration(bids_root: Path, tmp_path: Path):
     """Robust PET-to-anatomical registration swaps in mri_robust_register."""
     pet_series = [str(bids_root / 'sub-01' / 'pet' / 'sub-01_task-rest_run-1_pet.nii.gz')]

--- a/petprep/workflows/pet/tests/test_fit.py
+++ b/petprep/workflows/pet/tests/test_fit.py
@@ -481,10 +481,10 @@ def test_pet_fit_stage1_inclusion(bids_root: Path, tmp_path: Path):
     assert not any(name.startswith('pet_hmc_wf') for name in wf2.list_node_names())
 
 
-def test_pet_fit_auto_limits_hmc_memory_against_requested_resources(
+def test_pet_fit_hmc_policy_does_not_depend_on_requested_resources(
     bids_root: Path,
 ):
-    """Stage 1 should adapt mri_robust_template settings to tight memory budgets."""
+    """Stage 1 should not change HMC settings only because --mem is tight."""
     pet_series = [str(bids_root / 'sub-01' / 'pet' / 'sub-01_task-rest_run-1_pet.nii.gz')]
     img = nb.Nifti1Image(np.zeros((5, 5, 5, 4), dtype=np.float32), np.eye(4))
     for path in pet_series:
@@ -501,9 +501,9 @@ def test_pet_fit_auto_limits_hmc_memory_against_requested_resources(
         wf = init_pet_fit_wf(pet_series=pet_series, precomputed={}, omp_nthreads=1)
 
     robust_node = next(node for node in wf._get_all_nodes() if node.name == 'est_robust_hmc')
-    assert robust_node.inputs.fixed_timepoint is True
-    assert robust_node.inputs.no_iteration is True
-    assert robust_node.inputs.subsample_threshold == 200
+    assert robust_node.inputs.fixed_timepoint is False
+    assert robust_node.inputs.no_iteration is False
+    assert robust_node.inputs.subsample_threshold is Undefined
 
 
 def test_pet_fit_robust_registration(bids_root: Path, tmp_path: Path):

--- a/petprep/workflows/pet/tests/test_fit.py
+++ b/petprep/workflows/pet/tests/test_fit.py
@@ -506,6 +506,76 @@ def test_pet_fit_hmc_policy_does_not_depend_on_requested_resources(
     assert robust_node.inputs.subsample_threshold is Undefined
 
 
+@pytest.mark.parametrize(
+    ('subsample_threshold', 'expected_subsample_msg'),
+    [
+        (None, ''),
+        (159, ' with --subsample 159'),
+    ],
+)
+def test_pet_fit_logs_high_memory_hmc_policy(
+    bids_root: Path,
+    monkeypatch,
+    subsample_threshold,
+    expected_subsample_msg,
+):
+    """Stage 1 should log data-driven high-memory HMC settings."""
+    pet_series = [str(bids_root / 'sub-01' / 'pet' / 'sub-01_task-rest_run-1_pet.nii.gz')]
+    img = nb.Nifti1Image(np.zeros((5, 5, 5, 4), dtype=np.float32), np.eye(4))
+    for path in pet_series:
+        img.to_filename(path)
+        Path(path).with_suffix('').with_suffix('.json').write_text(
+            '{"FrameTimesStart": [0, 1, 2, 3], "FrameDuration": [1, 1, 1, 1]}'
+        )
+
+    def _fake_plan_hmc_resource_policy(*_args, **_kwargs):
+        return {
+            'estimated_memory_gb': 40.1,
+            'planned_memory_gb': 15.0,
+            'frame_memory_gb': 0.1,
+            'selected_frames': 41,
+            'start_frame': 0,
+            'total_frames': 41,
+            'subsample_threshold': subsample_threshold,
+            'fixed_frame': True,
+            'auto_limited': True,
+            'reason': '41 selected frames',
+        }
+
+    monkeypatch.setattr(pet_fit, 'plan_hmc_resource_policy', _fake_plan_hmc_resource_policy)
+
+    warnings = []
+    with mock_config(bids_dir=bids_root):
+        monkeypatch.setattr(
+            config.loggers.workflow,
+            'warning',
+            lambda message, *_args, **_kwargs: warnings.append(message),
+        )
+        config.workflow.hmc_off = False
+        config.workflow.hmc_fix_frame = False
+        config.workflow.petref = 'template'
+        wf = init_pet_fit_wf(pet_series=pet_series, precomputed={}, omp_nthreads=1)
+
+    robust_node = next(node for node in wf._get_all_nodes() if node.name == 'est_robust_hmc')
+    assert robust_node.mem_gb == 15.0
+    assert robust_node.inputs.fixed_timepoint is True
+    assert robust_node.inputs.no_iteration is True
+    if subsample_threshold is None:
+        assert robust_node.inputs.subsample_threshold is Undefined
+    else:
+        assert robust_node.inputs.subsample_threshold == subsample_threshold
+
+    assert len(warnings) == 1
+    warning = warnings[0]
+    assert 'selected high-memory settings' in warning
+    assert 'estimated 40.10 GB' in warning
+    assert '41/41 selected frames' in warning
+    assert 'planned estimate 15.00 GB' in warning
+    assert expected_subsample_msg in warning
+    if subsample_threshold is None:
+        assert 'with --subsample' not in warning
+
+
 def test_pet_fit_robust_registration(bids_root: Path, tmp_path: Path):
     """Robust PET-to-anatomical registration swaps in mri_robust_register."""
     pet_series = [str(bids_root / 'sub-01' / 'pet' / 'sub-01_task-rest_run-1_pet.nii.gz')]

--- a/petprep/workflows/pet/tests/test_hmc.py
+++ b/petprep/workflows/pet/tests/test_hmc.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 from nipype.interfaces.base import Undefined
 
+from .. import hmc as pet_hmc
 from ..hmc import (
     _estimate_hmc_gb,
     _find_highest_uptake_frame,
@@ -220,6 +221,47 @@ def test_plan_hmc_resource_policy_allows_forty_lowres_frames(tmp_path):
     assert policy['auto_limited'] is False
     assert policy['fixed_frame'] is False
     assert policy['subsample_threshold'] is None
+
+
+class _DummyImage:
+    def __init__(self, shape):
+        self.shape = shape
+        self.ndim = len(shape)
+
+
+def test_plan_hmc_resource_policy_allows_historical_dynamic_pet(monkeypatch):
+    monkeypatch.setattr(pet_hmc.nb, 'load', lambda _filename: _DummyImage((200, 200, 111, 33)))
+
+    policy = plan_hmc_resource_policy(
+        'pet.nii.gz',
+        start_time=0,
+        frame_durations=[1] * 33,
+        frame_start_times=list(range(33)),
+    )
+
+    assert policy['selected_frames'] == 33
+    assert policy['estimated_memory_gb'] < 24.0
+    assert policy['auto_limited'] is False
+    assert policy['fixed_frame'] is False
+    assert policy['subsample_threshold'] is None
+
+
+def test_plan_hmc_resource_policy_limits_high_resolution_pet(monkeypatch):
+    monkeypatch.setattr(pet_hmc.nb, 'load', lambda _filename: _DummyImage((300, 300, 300, 20)))
+
+    policy = plan_hmc_resource_policy(
+        'pet.nii.gz',
+        start_time=0,
+        frame_durations=[1] * 20,
+        frame_start_times=list(range(20)),
+    )
+
+    assert policy['selected_frames'] == 20
+    assert policy['estimated_memory_gb'] >= 24.0
+    assert policy['auto_limited'] is True
+    assert policy['fixed_frame'] is True
+    assert policy['subsample_threshold'] == 200
+    assert policy['planned_memory_gb'] < policy['estimated_memory_gb']
 
 
 def test_plan_hmc_resource_policy_limits_more_than_forty_frames(tmp_path):

--- a/petprep/workflows/pet/tests/test_hmc.py
+++ b/petprep/workflows/pet/tests/test_hmc.py
@@ -87,6 +87,12 @@ def test_init_pet_hmc_wf_without_subsample_threshold():
     assert '--subsample' not in wf.__desc__
 
 
+def test_init_pet_hmc_wf_records_disabled_memory_policy():
+    wf = init_pet_hmc_wf(mem_gb=1, omp_nthreads=1, memory_policy='off')
+
+    assert '--hmc-memory-policy off' in wf.__desc__
+
+
 def test_find_highest_uptake_frame(tmp_path):
     data = [np.ones((2, 2, 2)) * i for i in (1, 2, 3)]
     files = []

--- a/petprep/workflows/pet/tests/test_hmc.py
+++ b/petprep/workflows/pet/tests/test_hmc.py
@@ -4,8 +4,10 @@ import pytest
 
 from ..hmc import (
     _find_highest_uptake_frame,
+    estimate_hmc_mem_usage,
     get_start_frame,
     init_pet_hmc_wf,
+    plan_hmc_resource_policy,
     update_list_transforms,
 )
 

--- a/petprep/workflows/pet/tests/test_hmc.py
+++ b/petprep/workflows/pet/tests/test_hmc.py
@@ -5,6 +5,7 @@ from nipype.interfaces.base import Undefined
 
 from .. import hmc as pet_hmc
 from ..hmc import (
+    HMC_HIGH_MEMORY_GB,
     _estimate_hmc_gb,
     _find_highest_uptake_frame,
     _select_hmc_subsample_threshold,
@@ -240,7 +241,24 @@ def test_plan_hmc_resource_policy_allows_historical_dynamic_pet(monkeypatch):
     )
 
     assert policy['selected_frames'] == 33
-    assert policy['estimated_memory_gb'] < 24.0
+    assert policy['estimated_memory_gb'] < HMC_HIGH_MEMORY_GB
+    assert policy['auto_limited'] is False
+    assert policy['fixed_frame'] is False
+    assert policy['subsample_threshold'] is None
+
+
+def test_plan_hmc_resource_policy_allows_moderate_high_resolution_pet(monkeypatch):
+    monkeypatch.setattr(pet_hmc.nb, 'load', lambda _filename: _DummyImage((256, 256, 207, 28)))
+
+    policy = plan_hmc_resource_policy(
+        'pet.nii.gz',
+        start_time=0,
+        frame_durations=[1] * 28,
+        frame_start_times=list(range(28)),
+    )
+
+    assert policy['selected_frames'] == 28
+    assert policy['estimated_memory_gb'] < HMC_HIGH_MEMORY_GB
     assert policy['auto_limited'] is False
     assert policy['fixed_frame'] is False
     assert policy['subsample_threshold'] is None
@@ -257,7 +275,7 @@ def test_plan_hmc_resource_policy_limits_high_resolution_pet(monkeypatch):
     )
 
     assert policy['selected_frames'] == 20
-    assert policy['estimated_memory_gb'] >= 24.0
+    assert policy['estimated_memory_gb'] >= HMC_HIGH_MEMORY_GB
     assert policy['auto_limited'] is True
     assert policy['fixed_frame'] is True
     assert policy['subsample_threshold'] == 200

--- a/petprep/workflows/pet/tests/test_hmc.py
+++ b/petprep/workflows/pet/tests/test_hmc.py
@@ -1,9 +1,12 @@
 import nibabel as nb
 import numpy as np
 import pytest
+from nipype.interfaces.base import Undefined
 
 from ..hmc import (
+    _estimate_hmc_gb,
     _find_highest_uptake_frame,
+    _select_hmc_subsample_threshold,
     estimate_hmc_mem_usage,
     get_start_frame,
     init_pet_hmc_wf,
@@ -67,6 +70,23 @@ def test_init_pet_hmc_wf_specific_inittp():
     assert node.inputs.no_iteration is True
 
 
+def test_init_pet_hmc_wf_subsample_threshold():
+    wf = init_pet_hmc_wf(mem_gb=0, omp_nthreads=1, subsample_threshold=200)
+    node = wf.get_node('est_robust_hmc')
+
+    assert node.inputs.subsample_threshold == 200
+    assert node.mem_gb == 0.01
+    assert '--subsample 200' in wf.__desc__
+
+
+def test_init_pet_hmc_wf_without_subsample_threshold():
+    wf = init_pet_hmc_wf(mem_gb=1, omp_nthreads=1)
+    node = wf.get_node('est_robust_hmc')
+
+    assert node.inputs.subsample_threshold is Undefined
+    assert '--subsample' not in wf.__desc__
+
+
 def test_find_highest_uptake_frame(tmp_path):
     data = [np.ones((2, 2, 2)) * i for i in (1, 2, 3)]
     files = []
@@ -79,6 +99,24 @@ def test_find_highest_uptake_frame(tmp_path):
     expected = np.argmax([arr.sum() for arr in data]) + 1
     result = _find_highest_uptake_frame(files)
     assert result == expected
+
+
+def test_estimate_hmc_gb_rejects_non_spatial_shape():
+    with pytest.raises(ValueError, match='PET image must be 3D or 4D'):
+        _estimate_hmc_gb((5, 5), 2)
+
+
+def test_estimate_hmc_gb_clamps_frame_count():
+    zero_frame_estimate = _estimate_hmc_gb((5, 5, 5), 0)
+    one_frame_estimate = _estimate_hmc_gb((5, 5, 5), 1)
+
+    assert zero_frame_estimate == one_frame_estimate
+
+
+def test_select_hmc_subsample_threshold():
+    assert _select_hmc_subsample_threshold(256) == 200
+    assert _select_hmc_subsample_threshold(160) == 159
+    assert _select_hmc_subsample_threshold(150) is None
 
 
 def test_estimate_hmc_mem_usage_respects_start_time(tmp_path):
@@ -99,6 +137,26 @@ def test_estimate_hmc_mem_usage_respects_start_time(tmp_path):
     assert estimate['estimate'] > estimate['frame']
 
 
+def test_estimate_hmc_mem_usage_handles_3d_pet(tmp_path):
+    img = nb.Nifti1Image(np.zeros((5, 5, 5), dtype=np.float32), np.eye(4))
+    pet_file = tmp_path / 'pet.nii.gz'
+    img.to_filename(pet_file)
+
+    estimate = estimate_hmc_mem_usage(str(pet_file))
+
+    assert estimate['selected_frames'] == 1
+    assert estimate['total_frames'] == 1
+
+
+def test_estimate_hmc_mem_usage_rejects_non_3d_or_4d(tmp_path):
+    img = nb.Nifti1Image(np.zeros((5, 5), dtype=np.float32), np.eye(4))
+    pet_file = tmp_path / 'pet.nii.gz'
+    img.to_filename(pet_file)
+
+    with pytest.raises(ValueError, match='PET image must be 3D or 4D'):
+        estimate_hmc_mem_usage(str(pet_file))
+
+
 def test_estimate_hmc_mem_usage_subsample_threshold(tmp_path):
     img = nb.Nifti1Image(np.zeros((30, 25, 22, 2), dtype=np.uint8), np.eye(4))
     pet_file = tmp_path / 'pet.nii.gz'
@@ -109,6 +167,18 @@ def test_estimate_hmc_mem_usage_subsample_threshold(tmp_path):
 
     assert subsampled['estimate'] < full['estimate']
     assert subsampled['frame'] < full['frame']
+
+
+def test_estimate_hmc_mem_usage_keeps_shape_when_subsample_cannot_apply(tmp_path):
+    img = nb.Nifti1Image(np.zeros((30, 20, 22, 2), dtype=np.uint8), np.eye(4))
+    pet_file = tmp_path / 'pet.nii.gz'
+    img.to_filename(pet_file)
+
+    full = estimate_hmc_mem_usage(str(pet_file), subsample_threshold=None)
+    subsampled = estimate_hmc_mem_usage(str(pet_file), subsample_threshold=20)
+
+    assert subsampled['estimate'] == full['estimate']
+    assert subsampled['frame'] == full['frame']
 
 
 def test_plan_hmc_resource_policy_ignores_requested_memory(tmp_path):

--- a/petprep/workflows/pet/tests/test_hmc.py
+++ b/petprep/workflows/pet/tests/test_hmc.py
@@ -123,7 +123,7 @@ def test_estimate_hmc_mem_usage_subsample_threshold(tmp_path):
     assert subsampled['frame'] < full['frame']
 
 
-def test_plan_hmc_resource_policy_uses_requested_memory(tmp_path):
+def test_plan_hmc_resource_policy_ignores_requested_memory(tmp_path):
     img = nb.Nifti1Image(np.zeros((5, 5, 5, 4), dtype=np.float32), np.eye(4))
     pet_file = tmp_path / 'pet.nii.gz'
     img.to_filename(pet_file)
@@ -132,14 +132,12 @@ def test_plan_hmc_resource_policy_uses_requested_memory(tmp_path):
         str(pet_file),
         frame_durations=[1, 1, 1, 1],
         frame_start_times=[0, 1, 2, 3],
-        requested_memory_gb=0.00001,
         fixed_frame=False,
     )
 
-    assert policy['auto_limited'] is True
-    assert policy['fixed_frame'] is True
-    assert policy['subsample_threshold'] == 200
-    assert 'requested memory' in policy['reason']
+    assert policy['auto_limited'] is False
+    assert policy['fixed_frame'] is False
+    assert policy['subsample_threshold'] is None
 
 
 def test_plan_hmc_resource_policy_allows_forty_lowres_frames(tmp_path):
@@ -158,3 +156,60 @@ def test_plan_hmc_resource_policy_allows_forty_lowres_frames(tmp_path):
     assert policy['auto_limited'] is False
     assert policy['fixed_frame'] is False
     assert policy['subsample_threshold'] is None
+
+
+def test_plan_hmc_resource_policy_limits_more_than_forty_frames(tmp_path):
+    img = nb.Nifti1Image(np.zeros((5, 5, 5, 41), dtype=np.float32), np.eye(4))
+    pet_file = tmp_path / 'pet.nii.gz'
+    img.to_filename(pet_file)
+
+    policy = plan_hmc_resource_policy(
+        str(pet_file),
+        start_time=0,
+        frame_durations=[1] * 41,
+        frame_start_times=list(range(41)),
+    )
+
+    assert policy['selected_frames'] == 41
+    assert policy['auto_limited'] is True
+    assert policy['fixed_frame'] is True
+    assert policy['subsample_threshold'] is None
+    assert '41 selected frames' in policy['reason']
+
+
+def test_plan_hmc_resource_policy_skips_subsample_below_floor(tmp_path):
+    img = nb.Nifti1Image(np.zeros((100, 100, 100, 41), dtype=np.uint8), np.eye(4))
+    pet_file = tmp_path / 'pet.nii.gz'
+    img.to_filename(pet_file)
+
+    policy = plan_hmc_resource_policy(
+        str(pet_file),
+        start_time=0,
+        frame_durations=[1] * 41,
+        frame_start_times=list(range(41)),
+    )
+
+    assert policy['selected_frames'] == 41
+    assert policy['auto_limited'] is True
+    assert policy['fixed_frame'] is True
+    assert policy['subsample_threshold'] is None
+    assert policy['planned_memory_gb'] == policy['estimated_memory_gb']
+
+
+def test_plan_hmc_resource_policy_selects_dynamic_subsample_threshold(tmp_path):
+    img = nb.Nifti1Image(np.zeros((160, 160, 160, 41), dtype=np.uint8), np.eye(4))
+    pet_file = tmp_path / 'pet.nii.gz'
+    img.to_filename(pet_file)
+
+    policy = plan_hmc_resource_policy(
+        str(pet_file),
+        start_time=0,
+        frame_durations=[1] * 41,
+        frame_start_times=list(range(41)),
+    )
+
+    assert policy['selected_frames'] == 41
+    assert policy['auto_limited'] is True
+    assert policy['fixed_frame'] is True
+    assert policy['subsample_threshold'] == 159
+    assert policy['planned_memory_gb'] < policy['estimated_memory_gb']


### PR DESCRIPTION
This PR addresses issue #323, by adding a data-driven policy for PET head motion correction to reduce memory pressure from mri_robust_template on large dynamic or high-resolution PET scans.

The workflow now estimates expected HMC memory use from the PET image shape and selected frame count after --hmc-start-time. For high-risk scans, it automatically enables fixed initial-frame registration and, when spatial dimensions allow it safely, applies a FreeSurfer --subsample threshold. The subsample threshold is capped at 200 but lowered only as needed to satisfy FreeSurfer’s all-dimensions requirement, with a 150 voxel floor to avoid overly aggressive downsampling.

The decision is based on scan characteristics rather than requested runtime resources, and the selected policy is logged and included in the workflow boilerplate.