### PR TITLE
ENH: Improve memory estimates for dense PET and GTM workflows

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -140,6 +140,9 @@ This avoids very large anatomical and GTM segmentation grids when PET data are
 resampled into anatomical space. To opt in for submillimeter T1w inputs, pass
 ``--submm-recon``. The ``--no-submm-recon`` flag can be used to explicitly keep
 the default behavior.
+When GTM segmentation is requested, *PETPrep* reserves scheduler memory from
+the available FreeSurfer or T1w grid size, so high-resolution ``gtmseg`` runs
+are not treated as low-memory jobs.
 
 
 .. _prev_derivs:
@@ -241,9 +244,11 @@ single robust-template step while reducing peak memory pressure for long or
 high-resolution dynamic PET acquisitions without forcing a very coarse
 registration grid. The estimate, selected frame count and reason for the
 decision are recorded in the workflow log; the chosen HMC settings are reflected
-in the workflow boilerplate. Use :option:`--hmc-memory-policy` ``off`` to disable
-these automatic memory safeguards and run HMC with only the explicitly requested
-``mri_robust_template`` settings.
+in the workflow boilerplate. Independently of this policy, *PETPrep* also
+reserves memory for HMC preprocessing and PET reference-generation nodes from
+the PET series dimensions. Use :option:`--hmc-memory-policy` ``off`` to disable
+the robust-template memory safeguards and run HMC with only the explicitly
+requested ``mri_robust_template`` settings.
 
 When motion correction is undesirable, use :option:`--hmc-off` to disable head motion
 correction entirely and keep the data unmodified apart from downstream

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -245,10 +245,11 @@ high-resolution dynamic PET acquisitions without forcing a very coarse
 registration grid. The estimate, selected frame count and reason for the
 decision are recorded in the workflow log; the chosen HMC settings are reflected
 in the workflow boilerplate. Independently of this policy, *PETPrep* also
-reserves memory for HMC preprocessing and PET reference-generation nodes from
-the PET series dimensions. Use :option:`--hmc-memory-policy` ``off`` to disable
-the robust-template memory safeguards and run HMC with only the explicitly
-requested ``mri_robust_template`` settings.
+reserves memory for HMC preprocessing, PET reference-generation and volumetric
+resampling nodes from the PET series dimensions. Use
+:option:`--hmc-memory-policy` ``off`` to disable the robust-template memory
+safeguards and run HMC with only the explicitly requested
+``mri_robust_template`` settings.
 
 When motion correction is undesirable, use :option:`--hmc-off` to disable head motion
 correction entirely and keep the data unmodified apart from downstream

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -422,8 +422,9 @@ effect, but is not lowered below 150 voxels. This decision is data-driven and is
 recorded in the workflow log; the selected HMC settings are reflected in the
 workflow boilerplate. Independently of this policy, PET geometry estimates are
 also used to reserve scheduler memory for frame splitting, HMC preprocessing,
-and PET reference image generation. Use :option:`--hmc-memory-policy` ``off`` to
-disable the robust-template memory safeguards.
+PET reference image generation and volumetric resampling. Use
+:option:`--hmc-memory-policy` ``off`` to disable the robust-template memory
+safeguards.
 
 Pre-processed PET in native space
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/workflows.rst
+++ b/docs/workflows.rst
@@ -262,6 +262,9 @@ memory intensive on submillimeter anatomical grids. Use ``--submm-recon`` to opt
 in for T1w images with voxel sizes less than 1mm in all dimensions (rounding to
 nearest .1mm). The ``--no-submm-recon`` flag may be used to explicitly keep this
 default behavior.
+For GTM segmentation, *PETPrep* reserves scheduler memory from the available
+FreeSurfer or T1w grid size so high-resolution ``gtmseg`` runs are scheduled
+conservatively.
 
 If T2w or FLAIR images are available, and you do not want them included in
 FreeSurfer reconstruction, use ``--ignore t2w`` or ``--ignore flair``,
@@ -417,8 +420,10 @@ threshold of at most 200. The threshold is lowered below the smallest spatial
 dimension when needed so FreeSurfer's all-axis subsampling condition can take
 effect, but is not lowered below 150 voxels. This decision is data-driven and is
 recorded in the workflow log; the selected HMC settings are reflected in the
-workflow boilerplate. Use :option:`--hmc-memory-policy` ``off`` to disable these
-automatic memory safeguards.
+workflow boilerplate. Independently of this policy, PET geometry estimates are
+also used to reserve scheduler memory for frame splitting, HMC preprocessing,
+and PET reference image generation. Use :option:`--hmc-memory-policy` ``off`` to
+disable the robust-template memory safeguards.
 
 Pre-processed PET in native space
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/petprep/utils/misc.py
+++ b/petprep/utils/misc.py
@@ -25,6 +25,8 @@
 from functools import cache
 from pathlib import Path
 
+PET_RESAMPLE_MEMORY_SCALE = 8.0
+
 
 def check_deps(workflow):
     """Make sure dependencies are present in this system."""
@@ -85,7 +87,11 @@ def _estimate_pet_mem_usage_cached(
         'filesize': pet_size_gb,
         'frame': frame_size_gb,
         'reference': max(pet_size_gb * 1.5, pet_size_gb + frame_size_gb * 4),
-        'resampled': pet_size_gb * 4,
+        # Volumetric resampling keeps the source series, target/output series,
+        # dense coordinate grids and interpolation work arrays resident. The
+        # estimate is deliberately conservative so densely sampled runs do not
+        # get scheduled several-at-a-time by Nipype's MultiProc plugin.
+        'resampled': pet_size_gb * PET_RESAMPLE_MEMORY_SCALE,
         'largemem': pet_size_gb * (max(pet_tlen / 100, 1.0) + 4),
     }
 

--- a/petprep/utils/misc.py
+++ b/petprep/utils/misc.py
@@ -69,8 +69,10 @@ def _estimate_pet_mem_usage_cached(
 
     img = nb.load(pet_fname)
     nvox = int(np.prod(img.shape, dtype='u8'))
+    spatial_nvox = int(np.prod(img.shape[:3], dtype='u8'))
     # Assume tools will coerce to 8-byte floats to be safe
     pet_size_gb = 8 * nvox / (1024**3)
+    frame_size_gb = 8 * spatial_nvox / (1024**3)
 
     if img.ndim == 4:
         pet_tlen = img.shape[3]
@@ -81,6 +83,8 @@ def _estimate_pet_mem_usage_cached(
 
     mem_gb = {
         'filesize': pet_size_gb,
+        'frame': frame_size_gb,
+        'reference': max(pet_size_gb * 1.5, pet_size_gb + frame_size_gb * 4),
         'resampled': pet_size_gb * 4,
         'largemem': pet_size_gb * (max(pet_tlen / 100, 1.0) + 4),
     }

--- a/petprep/workflows/base.py
+++ b/petprep/workflows/base.py
@@ -263,10 +263,7 @@ def init_single_subject_wf(subject_id: str, session_id: str | list[str] | None =
 
     from petprep.interfaces.segmentation import ensure_mcr2019b_available
     from petprep.workflows.pet.base import init_pet_wf
-    from petprep.workflows.pet.segmentation import (
-        estimate_gtmseg_mem_usage,
-        init_segmentation_wf,
-    )
+    from petprep.workflows.pet.segmentation import init_segmentation_wf
 
     ses_str = _stringify_sessions(session_id)
     workflow = Workflow(
@@ -654,7 +651,6 @@ It is released under the [CC0]\
             subject_id=subject_id,
             session_id=session_id,
             t1w_files=subject_data['t1w'],
-            estimator=estimate_gtmseg_mem_usage,
         )
 
     segmentation_wf = init_segmentation_wf(
@@ -910,13 +906,15 @@ def _detect_existing_highres_freesurfer(subject_id):
     return None
 
 
-def _estimate_gtmseg_memory(*, subject_id, session_id, t1w_files, estimator):
+def _estimate_gtmseg_memory(*, subject_id, session_id, t1w_files):
     """Estimate GTM segmentation memory from available anatomical geometry."""
+    from petprep.workflows.pet.segmentation import estimate_gtmseg_mem_usage
+
     fs_subject_id = _subject_fs_id(subject_id, session_id)
     existing_highres = _detect_existing_highres_freesurfer(fs_subject_id)
     if existing_highres is not None:
         _, shape, _ = existing_highres
-        return estimator(spatial_shape=shape)
+        return estimate_gtmseg_mem_usage(spatial_shape=shape)
 
     if config.workflow.hires and t1w_files:
         try:
@@ -926,9 +924,9 @@ def _estimate_gtmseg_memory(*, subject_id, session_id, t1w_files, estimator):
                 f'Could not inspect T1w geometry for GTM memory estimation: {exc}'
             )
         else:
-            return estimator(spatial_shape=shape)
+            return estimate_gtmseg_mem_usage(spatial_shape=shape)
 
-    return estimator()
+    return estimate_gtmseg_mem_usage()
 
 
 def _warn_about_submillimeter_recon(*, subject_id, session_id, t1w_files, pet_runs):

--- a/petprep/workflows/base.py
+++ b/petprep/workflows/base.py
@@ -263,7 +263,10 @@ def init_single_subject_wf(subject_id: str, session_id: str | list[str] | None =
 
     from petprep.interfaces.segmentation import ensure_mcr2019b_available
     from petprep.workflows.pet.base import init_pet_wf
-    from petprep.workflows.pet.segmentation import init_segmentation_wf
+    from petprep.workflows.pet.segmentation import (
+        estimate_gtmseg_mem_usage,
+        init_segmentation_wf,
+    )
 
     ses_str = _stringify_sessions(session_id)
     workflow = Workflow(
@@ -645,9 +648,19 @@ It is released under the [CC0]\
     if config.workflow.seg in {'brainstem', 'hippocampusAmygdala', 'thalamicNuclei'}:
         ensure_mcr2019b_available()
 
+    gtm_mem_gb = None
+    if config.workflow.seg == 'gtm':
+        gtm_mem_gb = _estimate_gtmseg_memory(
+            subject_id=subject_id,
+            session_id=session_id,
+            t1w_files=subject_data['t1w'],
+            estimator=estimate_gtmseg_mem_usage,
+        )
+
     segmentation_wf = init_segmentation_wf(
         seg=config.workflow.seg,
         name=f'pet_{config.workflow.seg}_seg_wf',
+        gtm_mem_gb=gtm_mem_gb,
     )
     workflow.connect(
         [
@@ -895,6 +908,27 @@ def _detect_existing_highres_freesurfer(subject_id):
                 return gtmseg, shape, zooms
 
     return None
+
+
+def _estimate_gtmseg_memory(*, subject_id, session_id, t1w_files, estimator):
+    """Estimate GTM segmentation memory from available anatomical geometry."""
+    fs_subject_id = _subject_fs_id(subject_id, session_id)
+    existing_highres = _detect_existing_highres_freesurfer(fs_subject_id)
+    if existing_highres is not None:
+        _, shape, _ = existing_highres
+        return estimator(spatial_shape=shape)
+
+    if config.workflow.hires and t1w_files:
+        try:
+            shape, _ = _image_geometry(t1w_files[0])
+        except Exception as exc:  # noqa: BLE001
+            config.loggers.workflow.warning(
+                f'Could not inspect T1w geometry for GTM memory estimation: {exc}'
+            )
+        else:
+            return estimator(spatial_shape=shape)
+
+    return estimator()
 
 
 def _warn_about_submillimeter_recon(*, subject_id, session_id, t1w_files, pet_runs):

--- a/petprep/workflows/pet/fit.py
+++ b/petprep/workflows/pet/fit.py
@@ -628,6 +628,7 @@ def init_pet_fit_wf(
                 output_names=['out_file'],
             ),
             name='report_petref',
+            mem_gb=mem_gb['reference'],
         )
         report_pet_reference.inputs.output_dir = config.execution.work_dir
         report_pet_reference.inputs.frame_start_times = frame_start_times
@@ -647,6 +648,7 @@ def init_pet_fit_wf(
                 output_names=['out_file'],
             ),
             name=reference_node_name,
+            mem_gb=mem_gb['reference'],
         )
         corrected_reference.inputs.output_dir = config.execution.work_dir
         if petref_strategy in {'twa', 'first5min'}:
@@ -662,6 +664,7 @@ def init_pet_fit_wf(
                 output_names=['out_file'],
             ),
             name='auto_twa_reference',
+            mem_gb=mem_gb['reference'],
         )
         reference_nodes['twa'].inputs.output_dir = config.execution.work_dir
         reference_nodes['twa'].inputs.frame_start_times = frame_start_times
@@ -674,6 +677,7 @@ def init_pet_fit_wf(
                 output_names=['out_file'],
             ),
             name='auto_sum_reference',
+            mem_gb=mem_gb['reference'],
         )
         reference_nodes['sum'].inputs.output_dir = config.execution.work_dir
 
@@ -684,6 +688,7 @@ def init_pet_fit_wf(
                 output_names=['out_file'],
             ),
             name='auto_first5min_reference',
+            mem_gb=mem_gb['reference'],
         )
         reference_nodes['first5min'].inputs.output_dir = config.execution.work_dir
         reference_nodes['first5min'].inputs.frame_start_times = frame_start_times
@@ -833,6 +838,7 @@ def init_pet_fit_wf(
         elif config.workflow.hmc_memory_policy == 'off':
             hmc_policy = {
                 'planned_memory_gb': mem_gb['filesize'],
+                'source_frame_memory_gb': mem_gb['frame'],
                 'fixed_frame': config.workflow.hmc_fix_frame,
                 'subsample_threshold': None,
             }
@@ -856,6 +862,8 @@ def init_pet_fit_wf(
             initial_frame=config.workflow.hmc_init_frame,
             fixed_frame=hmc_policy['fixed_frame'],
             subsample_threshold=hmc_policy['subsample_threshold'],
+            source_file_mem_gb=mem_gb['filesize'],
+            frame_mem_gb=hmc_policy.get('source_frame_memory_gb', mem_gb['frame']),
             memory_policy=config.workflow.hmc_memory_policy,
         )
 

--- a/petprep/workflows/pet/hmc.py
+++ b/petprep/workflows/pet/hmc.py
@@ -343,9 +343,12 @@ def init_pet_hmc_wf(
     source_file_mem_gb : :obj:`float` or ``None``
         Estimated memory required to load the full PET series. Used to reserve
         memory for frame splitting before robust-template subsampling applies.
+        If omitted, ``mem_gb`` is used for frame splitting.
     frame_mem_gb : :obj:`float` or ``None``
         Estimated memory required to load one full-resolution PET frame. Used
         to reserve memory for smoothing and thresholding each selected frame.
+        If omitted, per-frame preprocessing nodes use Nipype's default memory
+        accounting to preserve compatibility with direct workflow callers.
     memory_policy : {'auto', 'off'}
         Whether automatic HMC memory safeguards were enabled for this workflow.
     name : :obj:`str`
@@ -374,10 +377,12 @@ def init_pet_hmc_wf(
         float(source_file_mem_gb if source_file_mem_gb is not None else mem_gb),
         0.01,
     )
-    frame_mem_gb = max(
-        float(frame_mem_gb if frame_mem_gb is not None else source_file_mem_gb),
-        0.01,
-    )
+    frame_mem_gb = max(float(frame_mem_gb), 0.01) if frame_mem_gb is not None else None
+
+    def _frame_mem_kwargs(scale: float) -> dict[str, float]:
+        if frame_mem_gb is None:
+            return {}
+        return {'mem_gb': max(frame_mem_gb * scale, 0.1)}
 
     workflow = Workflow(name=name)
     workflow.__desc__ = """\
@@ -451,13 +456,13 @@ disabling robust-template iterations.
         fsl.Smooth(fwhm=fwhm),
         name='smooth',
         iterfield=['in_file'],
-        mem_gb=max(frame_mem_gb * 4, 0.1),
+        **_frame_mem_kwargs(4),
     )
     thresh = pe.MapNode(
         fsl.maths.Threshold(thresh=20, use_robust_range=True),
         name='thresh',
         iterfield=['in_file'],
-        mem_gb=max(frame_mem_gb * 2, 0.1),
+        **_frame_mem_kwargs(2),
     )
 
     # Select reference frame
@@ -489,7 +494,7 @@ disabling robust-template iterations.
                 function=_find_highest_uptake_frame,
             ),
             name='find_highest_uptake_frame',
-            mem_gb=max(frame_mem_gb * 2, 0.1),
+            **_frame_mem_kwargs(2),
         )
 
     # Motion estimation
@@ -527,7 +532,7 @@ disabling robust-template iterations.
     ref_to_nii = pe.Node(
         fs.MRIConvert(out_type='niigz'),
         name='convert_ref',
-        mem_gb=max(frame_mem_gb * 2, 0.1),
+        **_frame_mem_kwargs(2),
     )
 
     workflow.connect([

--- a/petprep/workflows/pet/hmc.py
+++ b/petprep/workflows/pet/hmc.py
@@ -234,6 +234,7 @@ def plan_hmc_resource_policy(
         'estimated_memory_gb': estimate['estimate'],
         'planned_memory_gb': planned_estimate['estimate'],
         'frame_memory_gb': planned_estimate['frame'],
+        'source_frame_memory_gb': estimate['frame'],
         'selected_frames': estimate['selected_frames'],
         'start_frame': estimate['start_frame'],
         'total_frames': estimate['total_frames'],
@@ -286,6 +287,8 @@ def init_pet_hmc_wf(
     initial_frame: int | str | None = 'auto',
     fixed_frame: bool = False,
     subsample_threshold: int | None = None,
+    source_file_mem_gb: float | None = None,
+    frame_mem_gb: float | None = None,
     memory_policy: str = 'auto',
     name: str = 'pet_hmc_wf',
 ):
@@ -337,6 +340,12 @@ def init_pet_hmc_wf(
     subsample_threshold : :obj:`int` or ``None``
         FreeSurfer ``mri_robust_template --subsample`` threshold. If ``None``,
         robust-template subsampling is not requested.
+    source_file_mem_gb : :obj:`float` or ``None``
+        Estimated memory required to load the full PET series. Used to reserve
+        memory for frame splitting before robust-template subsampling applies.
+    frame_mem_gb : :obj:`float` or ``None``
+        Estimated memory required to load one full-resolution PET frame. Used
+        to reserve memory for smoothing and thresholding each selected frame.
     memory_policy : {'auto', 'off'}
         Whether automatic HMC memory safeguards were enabled for this workflow.
     name : :obj:`str`
@@ -360,6 +369,15 @@ def init_pet_hmc_wf(
 
     """
     from niworkflows.engine.workflows import LiterateWorkflow as Workflow
+
+    source_file_mem_gb = max(
+        float(source_file_mem_gb if source_file_mem_gb is not None else mem_gb),
+        0.01,
+    )
+    frame_mem_gb = max(
+        float(frame_mem_gb if frame_mem_gb is not None else source_file_mem_gb),
+        0.01,
+    )
 
     workflow = Workflow(name=name)
     workflow.__desc__ = """\
@@ -397,7 +415,11 @@ disabling robust-template iterations.
     outputnode = pe.Node(niu.IdentityInterface(fields=['xforms', 'petref']), name='outputnode')
 
     # Split frames
-    split = pe.Node(fs.MRIConvert(out_type='niigz', split=True), name='split_frames')
+    split = pe.Node(
+        fs.MRIConvert(out_type='niigz', split=True),
+        name='split_frames',
+        mem_gb=source_file_mem_gb,
+    )
 
     # After splitting, explicitly select frames
     select_frames = pe.Node(Select(), name='select_frames')
@@ -429,9 +451,13 @@ disabling robust-template iterations.
         fsl.Smooth(fwhm=fwhm),
         name='smooth',
         iterfield=['in_file'],
+        mem_gb=max(frame_mem_gb * 4, 0.1),
     )
     thresh = pe.MapNode(
-        fsl.maths.Threshold(thresh=20, use_robust_range=True), name='thresh', iterfield=['in_file']
+        fsl.maths.Threshold(thresh=20, use_robust_range=True),
+        name='thresh',
+        iterfield=['in_file'],
+        mem_gb=max(frame_mem_gb * 2, 0.1),
     )
 
     # Select reference frame
@@ -463,6 +489,7 @@ disabling robust-template iterations.
                 function=_find_highest_uptake_frame,
             ),
             name='find_highest_uptake_frame',
+            mem_gb=max(frame_mem_gb * 2, 0.1),
         )
 
     # Motion estimation
@@ -497,7 +524,11 @@ disabling robust-template iterations.
     # Convert to ITK
     lta2itk = pe.Node(LTAList2ITK(), name='convert_lta2itk', mem_gb=0.05, n_procs=omp_nthreads)
 
-    ref_to_nii = pe.Node(fs.MRIConvert(out_type='niigz'), name='convert_ref')
+    ref_to_nii = pe.Node(
+        fs.MRIConvert(out_type='niigz'),
+        name='convert_ref',
+        mem_gb=max(frame_mem_gb * 2, 0.1),
+    )
 
     workflow.connect([
         (inputnode, split, [('pet_file', 'in_file')]),

--- a/petprep/workflows/pet/segmentation.py
+++ b/petprep/workflows/pet/segmentation.py
@@ -42,12 +42,20 @@ except Exception:  # pragma: no cover - Py<3.9 fallback
 
 SEG_DATA = ir_files('petprep.data.segmentation')
 ATLAS_CONFIG = load_atlas_config()
+# ``gtmseg`` can keep several label, tissue and working volumes resident.
+# Reserve a conservative floor for ordinary 1 mm FreeSurfer grids and scale
+# high-resolution grids by an approximate stack of double-precision volumes
+# plus process overhead.
 GTMSEG_MEMORY_FLOOR_GB = 16.0
 GTMSEG_MEMORY_SCALE = 12.0
 
 
 def estimate_gtmseg_mem_usage(spatial_shape: tuple[int, int, int] | None = None) -> float:
-    """Estimate memory required by FreeSurfer's ``gtmseg`` command."""
+    """Estimate memory required by FreeSurfer's ``gtmseg`` command.
+
+    The estimate is intentionally conservative for Nipype scheduling and is not
+    intended to predict exact resident set size.
+    """
     if spatial_shape is None:
         return GTMSEG_MEMORY_FLOOR_GB
 

--- a/petprep/workflows/pet/segmentation.py
+++ b/petprep/workflows/pet/segmentation.py
@@ -1,6 +1,8 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 """Segmentation workflows."""
 
+from math import prod
+
 from nipype import Function
 from nipype.interfaces import utility as niu
 from nipype.interfaces.freesurfer import MRIConvert
@@ -40,6 +42,17 @@ except Exception:  # pragma: no cover - Py<3.9 fallback
 
 SEG_DATA = ir_files('petprep.data.segmentation')
 ATLAS_CONFIG = load_atlas_config()
+GTMSEG_MEMORY_FLOOR_GB = 16.0
+GTMSEG_MEMORY_SCALE = 12.0
+
+
+def estimate_gtmseg_mem_usage(spatial_shape: tuple[int, int, int] | None = None) -> float:
+    """Estimate memory required by FreeSurfer's ``gtmseg`` command."""
+    if spatial_shape is None:
+        return GTMSEG_MEMORY_FLOOR_GB
+
+    frame_gb = 8 * prod(spatial_shape[:3]) / (1024**3)
+    return max(GTMSEG_MEMORY_FLOOR_GB, 4.0 + frame_gb * GTMSEG_MEMORY_SCALE)
 
 
 def _merge_ha_labels(lh_file: str, rh_file: str) -> str:
@@ -326,7 +339,12 @@ def _build_template_atlas_nodes(seg: str):
     return nodes
 
 
-def init_segmentation_wf(seg: str = 'gtm', name: str | None = None) -> Workflow:
+def init_segmentation_wf(
+    seg: str = 'gtm',
+    name: str | None = None,
+    *,
+    gtm_mem_gb: float | None = None,
+) -> Workflow:
     """Return a minimal segmentation workflow selecting a FreeSurfer command."""
     name = name or f'pet_{seg}_seg_wf'
     workflow = Workflow(name=name)
@@ -451,7 +469,16 @@ def init_segmentation_wf(seg: str = 'gtm', name: str | None = None) -> Workflow:
         return workflow
 
     interface = spec['interface']
-    seg_node = pe.Node(interface(**spec.get('interface_kwargs', {})), name=f'run_{seg}')
+    node_kwargs = {}
+    if seg == 'gtm':
+        node_kwargs['mem_gb'] = (
+            float(gtm_mem_gb) if gtm_mem_gb is not None else estimate_gtmseg_mem_usage()
+        )
+    seg_node = pe.Node(
+        interface(**spec.get('interface_kwargs', {})),
+        name=f'run_{seg}',
+        **node_kwargs,
+    )
 
     for in_field, out_field in spec.get('inputs', []):
         workflow.connect([(inputnode, seg_node, [(in_field, out_field)])])

--- a/petprep/workflows/pet/tests/test_fit.py
+++ b/petprep/workflows/pet/tests/test_fit.py
@@ -355,6 +355,31 @@ def test_petref_auto_mixed_3d_and_4d_pet_runs(bids_root: Path, tmp_path: Path):
     assert wf_4d.get_node('summary').inputs.petref_strategy == 'auto'
 
 
+def test_pet_reference_nodes_use_estimated_memory(bids_root: Path):
+    from ....utils.misc import estimate_pet_mem_usage
+
+    pet_file = bids_root / 'sub-01' / 'pet' / 'sub-01_task-rest_run-1_pet.nii.gz'
+    nb.Nifti1Image(np.zeros((3, 3, 3, 2), dtype=np.float32), np.eye(4)).to_filename(pet_file)
+    pet_file.with_suffix('').with_suffix('.json').write_text(
+        '{"FrameTimesStart": [0, 1], "FrameDuration": [1, 1]}'
+    )
+
+    estimate_pet_mem_usage.cache_clear()
+    try:
+        _, mem_gb = estimate_pet_mem_usage(str(pet_file))
+        with mock_config(bids_dir=bids_root):
+            config.workflow.petref = 'auto'
+            wf = init_pet_fit_wf(pet_series=[str(pet_file)], precomputed={}, omp_nthreads=1)
+    finally:
+        estimate_pet_mem_usage.cache_clear()
+
+    expected = mem_gb['reference']
+    assert wf.get_node('report_petref').mem_gb == expected
+    assert wf.get_node('auto_twa_reference').mem_gb == expected
+    assert wf.get_node('auto_sum_reference').mem_gb == expected
+    assert wf.get_node('auto_first5min_reference').mem_gb == expected
+
+
 def test_pet_reference_utilities(tmp_path: Path):
     labels = ['template', 'twa', 'sum']
     scores = [0.5, None, 0.25]

--- a/petprep/workflows/pet/tests/test_hmc.py
+++ b/petprep/workflows/pet/tests/test_hmc.py
@@ -81,6 +81,21 @@ def test_init_pet_hmc_wf_subsample_threshold():
     assert '--subsample 200' in wf.__desc__
 
 
+def test_init_pet_hmc_wf_preprocessing_memory():
+    wf = init_pet_hmc_wf(
+        mem_gb=5,
+        omp_nthreads=1,
+        source_file_mem_gb=2,
+        frame_mem_gb=0.25,
+    )
+
+    assert wf.get_node('split_frames').mem_gb == 2
+    assert wf.get_node('smooth').mem_gb == 1
+    assert wf.get_node('thresh').mem_gb == 0.5
+    assert wf.get_node('find_highest_uptake_frame').mem_gb == 0.5
+    assert wf.get_node('convert_ref').mem_gb == 0.5
+
+
 def test_init_pet_hmc_wf_without_subsample_threshold():
     wf = init_pet_hmc_wf(mem_gb=1, omp_nthreads=1)
     node = wf.get_node('est_robust_hmc')
@@ -280,6 +295,7 @@ def test_plan_hmc_resource_policy_limits_high_resolution_pet(monkeypatch):
     assert policy['fixed_frame'] is True
     assert policy['subsample_threshold'] == 200
     assert policy['planned_memory_gb'] < policy['estimated_memory_gb']
+    assert policy['source_frame_memory_gb'] > policy['frame_memory_gb']
 
 
 def test_plan_hmc_resource_policy_limits_more_than_forty_frames(tmp_path):

--- a/petprep/workflows/pet/tests/test_hmc.py
+++ b/petprep/workflows/pet/tests/test_hmc.py
@@ -96,6 +96,17 @@ def test_init_pet_hmc_wf_preprocessing_memory():
     assert wf.get_node('convert_ref').mem_gb == 0.5
 
 
+def test_init_pet_hmc_wf_preserves_default_preprocessing_memory():
+    wf = init_pet_hmc_wf(mem_gb=5, omp_nthreads=1)
+
+    default_mem_gb = wf.get_node('smooth').mem_gb
+    assert wf.get_node('split_frames').mem_gb == 5
+    assert default_mem_gb < wf.get_node('split_frames').mem_gb
+    assert wf.get_node('thresh').mem_gb == default_mem_gb
+    assert wf.get_node('find_highest_uptake_frame').mem_gb == default_mem_gb
+    assert wf.get_node('convert_ref').mem_gb == default_mem_gb
+
+
 def test_init_pet_hmc_wf_without_subsample_threshold():
     wf = init_pet_hmc_wf(mem_gb=1, omp_nthreads=1)
     node = wf.get_node('est_robust_hmc')

--- a/petprep/workflows/pet/tests/test_mem.py
+++ b/petprep/workflows/pet/tests/test_mem.py
@@ -1,7 +1,7 @@
 import nibabel as nb
 import numpy as np
 
-from petprep.utils.misc import estimate_pet_mem_usage
+from petprep.utils.misc import PET_RESAMPLE_MEMORY_SCALE, estimate_pet_mem_usage
 
 
 def test_estimate_pet_mem_usage(tmp_path):
@@ -16,7 +16,7 @@ def test_estimate_pet_mem_usage(tmp_path):
     assert np.isclose(mem['filesize'], size)
     assert np.isclose(mem['frame'], frame_size)
     assert np.isclose(mem['reference'], max(size * 1.5, size + frame_size * 4))
-    assert np.isclose(mem['resampled'], size * 4)
+    assert np.isclose(mem['resampled'], size * PET_RESAMPLE_MEMORY_SCALE)
     assert np.isclose(mem['largemem'], size * (max(tlen / 100, 1.0) + 4))
 
 

--- a/petprep/workflows/pet/tests/test_mem.py
+++ b/petprep/workflows/pet/tests/test_mem.py
@@ -11,8 +11,11 @@ def test_estimate_pet_mem_usage(tmp_path):
 
     tlen, mem = estimate_pet_mem_usage(str(pet_file))
     size = 8 * np.prod(img.shape) / (1024**3)
+    frame_size = 8 * np.prod(img.shape[:3]) / (1024**3)
     assert tlen == 10
     assert np.isclose(mem['filesize'], size)
+    assert np.isclose(mem['frame'], frame_size)
+    assert np.isclose(mem['reference'], max(size * 1.5, size + frame_size * 4))
     assert np.isclose(mem['resampled'], size * 4)
     assert np.isclose(mem['largemem'], size * (max(tlen / 100, 1.0) + 4))
 

--- a/petprep/workflows/pet/tests/test_segmentation.py
+++ b/petprep/workflows/pet/tests/test_segmentation.py
@@ -3,7 +3,12 @@ import numpy as np
 import pytest
 
 from ...tests import mock_config
-from ..segmentation import _merge_ha_labels, init_segmentation_wf
+from ..segmentation import (
+    GTMSEG_MEMORY_FLOOR_GB,
+    _merge_ha_labels,
+    estimate_gtmseg_mem_usage,
+    init_segmentation_wf,
+)
 
 
 def test_segmentation_node_selection():
@@ -26,6 +31,26 @@ def test_segmentation_node_selection():
         assert 'segstats_aparcaseg' in names_aparcaseg
         assert 'create_aparcaseg_dsegtsv' in names_aparcaseg
         assert 'create_aparcaseg_morphtsv' in names_aparcaseg
+
+
+def test_gtm_segmentation_memory_reservation():
+    """GTM segmentation should reserve realistic scheduler memory."""
+    with mock_config():
+        wf = init_segmentation_wf('gtm')
+        assert wf.get_node('run_gtm').mem_gb == GTMSEG_MEMORY_FLOOR_GB
+
+        wf_highres = init_segmentation_wf('gtm', gtm_mem_gb=42.0)
+        assert wf_highres.get_node('run_gtm').mem_gb == 42.0
+
+
+def test_estimate_gtmseg_mem_usage_scales_with_grid():
+    """Large anatomical grids should schedule GTM as a high-memory node."""
+    standard = estimate_gtmseg_mem_usage((256, 256, 256))
+    highres = estimate_gtmseg_mem_usage((682, 762, 820))
+
+    assert standard == GTMSEG_MEMORY_FLOOR_GB
+    assert highres > standard
+    assert highres > 40
 
 
 def test_merge_ha_labels(tmp_path):

--- a/petprep/workflows/tests/test_base.py
+++ b/petprep/workflows/tests/test_base.py
@@ -19,6 +19,7 @@ from ..base import (
     _build_reference_mask_boilerplate,
     _build_segmentation_boilerplate,
     _detect_existing_highres_freesurfer,
+    _estimate_gtmseg_memory,
     _fix_multi_source_name,
     _fmt_group,
     _format_geometry,
@@ -437,6 +438,63 @@ def test_detect_existing_highres_freesurfer_handles_unreadable_gtmseg(
         monkeypatch.setattr(base_module, '_image_geometry', _raise_runtime_error)
 
         assert _detect_existing_highres_freesurfer('sub-01') is None
+
+
+def test_estimate_gtmseg_memory_uses_existing_highres_geometry(bids_root, tmp_path, monkeypatch):
+    with mock_config(bids_dir=bids_root):
+        config.execution.fs_subjects_dir = tmp_path / 'freesurfer'
+
+        def fake_detect(subject_id):
+            assert subject_id == 'sub-01'
+            return tmp_path / 'gtmseg.mgz', (682, 762, 820), (0.244, 0.244, 0.244)
+
+        monkeypatch.setattr(base_module, '_detect_existing_highres_freesurfer', fake_detect)
+
+        observed = {}
+
+        def fake_estimator(*, spatial_shape=None):
+            observed['shape'] = spatial_shape
+            return 41.0
+
+        mem_gb = _estimate_gtmseg_memory(
+            subject_id='01',
+            session_id=None,
+            t1w_files=[],
+            estimator=fake_estimator,
+        )
+
+    assert mem_gb == 41.0
+    assert observed['shape'] == (682, 762, 820)
+
+
+def test_estimate_gtmseg_memory_uses_hires_t1w_geometry(bids_root, tmp_path, monkeypatch):
+    t1w_file = tmp_path / 'sub-01_T1w.nii.gz'
+    t1w_file.write_text('placeholder')
+
+    with mock_config(bids_dir=bids_root):
+        config.workflow.hires = True
+        monkeypatch.setattr(base_module, '_detect_existing_highres_freesurfer', lambda _: None)
+        monkeypatch.setattr(
+            base_module,
+            '_image_geometry',
+            lambda image_file: ((320, 320, 320), (0.8, 0.8, 0.8)),
+        )
+
+        observed = {}
+
+        def fake_estimator(*, spatial_shape=None):
+            observed['shape'] = spatial_shape
+            return 16.0
+
+        mem_gb = _estimate_gtmseg_memory(
+            subject_id='01',
+            session_id=None,
+            t1w_files=[t1w_file],
+            estimator=fake_estimator,
+        )
+
+    assert mem_gb == 16.0
+    assert observed['shape'] == (320, 320, 320)
 
 
 def test_warn_about_submillimeter_recon_branches(bids_root, tmp_path, monkeypatch):

--- a/petprep/workflows/tests/test_base.py
+++ b/petprep/workflows/tests/test_base.py
@@ -191,6 +191,24 @@ def test_segmentation_shared_across_runs(multisession_bids_root):
         assert all('_seg_wf' not in n for n in pet_node.list_node_names())
 
 
+def test_gtm_memory_estimate_propagates_to_segmentation_wf(multisession_bids_root, monkeypatch):
+    from ..pet.segmentation import estimate_gtmseg_mem_usage
+
+    highres_shape = (682, 762, 820)
+
+    def fake_detect(_subject_id):
+        return Path('/fake/gtmseg.mgz'), highres_shape, (0.244, 0.244, 0.244)
+
+    with mock_config(bids_dir=multisession_bids_root):
+        config.workflow.seg = 'gtm'
+        monkeypatch.setattr(base_module, '_detect_existing_highres_freesurfer', fake_detect)
+        wf = init_single_subject_wf('01')
+
+    seg_wf = wf.get_node('pet_gtm_seg_wf')
+    run_gtm = seg_wf.get_node('run_gtm')
+    assert run_gtm.mem_gb == estimate_gtmseg_mem_usage(spatial_shape=highres_shape)
+
+
 def test_segmentation_boilerplate_mentions_atlas_reference():
     desc = _build_segmentation_boilerplate('MASSP20')
     assert 'atlas' in desc
@@ -456,11 +474,15 @@ def test_estimate_gtmseg_memory_uses_existing_highres_geometry(bids_root, tmp_pa
             observed['shape'] = spatial_shape
             return 41.0
 
+        monkeypatch.setattr(
+            'petprep.workflows.pet.segmentation.estimate_gtmseg_mem_usage',
+            fake_estimator,
+        )
+
         mem_gb = _estimate_gtmseg_memory(
             subject_id='01',
             session_id=None,
             t1w_files=[],
-            estimator=fake_estimator,
         )
 
     assert mem_gb == 41.0
@@ -486,11 +508,15 @@ def test_estimate_gtmseg_memory_uses_hires_t1w_geometry(bids_root, tmp_path, mon
             observed['shape'] = spatial_shape
             return 16.0
 
+        monkeypatch.setattr(
+            'petprep.workflows.pet.segmentation.estimate_gtmseg_mem_usage',
+            fake_estimator,
+        )
+
         mem_gb = _estimate_gtmseg_memory(
             subject_id='01',
             session_id=None,
             t1w_files=[t1w_file],
-            estimator=fake_estimator,
         )
 
     assert mem_gb == 16.0


### PR DESCRIPTION
This PR makes PETPrep’s Nipype scheduling more conservative for memory-heavy PET workflows.

Changes include:
1. Add PET memory estimates for per-frame and reference-generation workloads
2. Apply estimated memory to PET reference nodes
3. Reserve memory for HMC split/smooth/threshold steps
4. Add explicit GTM segmentation memory estimates
5. Scale GTM memory when high-resolution FreeSurfer or submillimeter T1w geometry is detected

This should reduce BrokenProcessPool failures caused by underestimating memory and running too many large nodes concurrently.