### PR TITLE
Add codespell support with configuration and fixes

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Codespell
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/.maint/ROADMAP.md
+++ b/.maint/ROADMAP.md
@@ -4,4 +4,4 @@ This document states how the roadmap is built, discussed and monitored by the Ma
 
 For example, if the GitHub Projects feature is used, this document will contain a link to the corresponding Project and document who is responsible of managing the project, contacting Contributors and Maintainers to monitor the progress of activities, organizing meetings and discussions around the activities, etc.
 
-This document may also indicate how the *milestones* feature of the project is used and, as for Projects, who is responsible of what coordination actions, their frequence, etc.
+This document may also indicate how the *milestones* feature of the project is used and, as for Projects, who is responsible of what coordination actions, their frequency, etc.

--- a/.maint/update_changes.sh
+++ b/.maint/update_changes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Collects the pull-requests since the latest release and
-# aranges them in the CHANGES.rst.txt file.
+# arranges them in the CHANGES.rst.txt file.
 #
 # This is a script to be run before releasing a new version.
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,3 +209,10 @@ source = [
   "wrapper",
   "**/site-packages/petprep"
 ]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git,.gitignore,.gitattributes,*.svg,*.css,*.gii'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,12 @@ source = [
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git,.gitignore,.gitattributes,*.svg,*.css,*.gii'
+# petprep/data/tests contains a BIDS fixture dataset and generated HTML reports
+# whose chopped tags and escaped newlines yield many false positives.
+# .mailmap holds email addresses that trip word-level checks.
+skip = '.git,.gitignore,.gitattributes,*.svg,*.css,*.gii,.mailmap,*/petprep/data/tests/*'
 check-hidden = true
-# ignore-regex = ''
-# ignore-words-list = ''
+# Protect URLs from being "fixed" even if they contain typos.
+ignore-regex = 'https?://\S+'
+# Surnames appearing in BibTeX author lists in petprep/data/boilerplate.bib
+ignore-words-list = 'gage,claus'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,7 +215,7 @@ source = [
 # petprep/data/tests contains a BIDS fixture dataset and generated HTML reports
 # whose chopped tags and escaped newlines yield many false positives.
 # .mailmap holds email addresses that trip word-level checks.
-skip = '.git,.gitignore,.gitattributes,*.svg,*.css,*.gii,.mailmap,*/petprep/data/tests/*'
+skip = '.git,.gitignore,.gitattributes,.tox,.git-meta,*.svg,*.css,*.gii,.mailmap,*/petprep/data/tests/*'
 check-hidden = true
 # Protect URLs from being "fixed" even if they contain typos.
 ignore-regex = 'https?://\S+'

--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,7 @@ deps =
   codespell[toml]
 skip_install = true
 commands =
-  codespell . --skip="*.svg,*.html,*.bib,*.ipynb" {posargs}
+  codespell . {posargs}
 
 [testenv:build{,-strict}]
 labels =


### PR DESCRIPTION
Add [codespell][cs] support — a CI workflow and a tuned config in
`pyproject.toml` — and fix the genuine typos it surfaces.

[cs]: https://github.com/codespell-project/codespell

I have introduced codespell to over a hundred projects already, mostly
with positive feedback (see the [improveit-dashboard][rep] write-up for
context). The CI workflow's `permissions` is `contents: read` only, so
it has no write access to the repository.

[rep]: https://github.com/yarikoptic/improveit-dashboard/blob/master/READMEs/yarikoptic.md

## Changes

### Configuration & Infrastructure
- New GitHub Actions workflow (`.github/workflows/codespell.yml`)
  running on push to `main` and on PRs targeting `main`.
- `[tool.codespell]` table in `pyproject.toml`, configured to:
  - Skip the generated test fixtures under `petprep/data/tests/*` —
    HTML reportlets and a BIDS `dataset_description.json` with
    `\n`-escaped strings produced a lot of chopped-token false
    positives (`ehR`, `BvE`, `boXS`, `nWe`, …).
  - Skip `.mailmap` (institutional email addresses like `bu.edu` tripped
    word-level checks).
  - Skip `*.svg`, `*.css`, `*.gii` (binary-ish / generated formats).
  - Protect URLs from being "fixed" via `ignore-regex = 'https?://\S+'`.
  - Whitelist surnames found in BibTeX author lists in
    `petprep/data/boilerplate.bib`: `Gage`, `Claus`.

### Typo Fixes
Two genuine typos found by codespell:

| Before     | After      | Location                  |
|------------|------------|---------------------------|
| `frequence`| `frequency`| `.maint/ROADMAP.md:7`     |
| `aranges`  | `arranges` | `.maint/update_changes.sh:4` |

Both are in comments / prose, not in code identifiers, so they have no
functional impact.

## Testing

Verified locally (and on a fresh clone of this branch) that codespell
exits with `0` and no warnings:

```
$ uvx codespell
$ echo $?
0
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) and love to typos free code
