### PR TITLE
FIX: adapt memory usage for MotionPlot to PET data

### DIFF
--- a/petprep/utils/misc.py
+++ b/petprep/utils/misc.py
@@ -83,9 +83,19 @@ def _estimate_pet_mem_usage_cached(
         'filesize': pet_size_gb,
         'resampled': pet_size_gb * 4,
         'largemem': pet_size_gb * (max(pet_tlen / 100, 1.0) + 4),
+        'motion_report': _estimate_motion_report_mem_gb(pet_size_gb, pet_tlen),
     }
 
     return pet_tlen, mem_gb
+
+
+def _estimate_motion_report_mem_gb(pet_size_gb: float, pet_tlen: int) -> float:
+    """Estimate memory for the animated motion-correction reportlet."""
+    # MotionPlot may touch the original and corrected 4D series, then retains
+    # rendered before/after PNG frames and a base64-encoded SVG payload.
+    image_buffers_gb = pet_size_gb * 2.5
+    rendered_frames_gb = max(int(pet_tlen), 1) * 0.03
+    return max(1.0, image_buffers_gb + rendered_frames_gb)
 
 
 estimate_pet_mem_usage.cache_clear = _estimate_pet_mem_usage_cached.cache_clear

--- a/petprep/workflows/pet/base.py
+++ b/petprep/workflows/pet/base.py
@@ -277,9 +277,7 @@ configured with cubic B-spline interpolation.
     ])  # fmt:skip
 
     if nvols > 1:
-        motion_report = pe.Node(
-            MotionPlot(), name='motion_report', mem_gb=mem_gb['motion_report']
-        )
+        motion_report = pe.Node(MotionPlot(), name='motion_report', mem_gb=mem_gb['motion_report'])
         ds_motion_report = pe.Node(
             DerivativesDataSink(
                 base_directory=petprep_dir,

--- a/petprep/workflows/pet/base.py
+++ b/petprep/workflows/pet/base.py
@@ -277,7 +277,9 @@ configured with cubic B-spline interpolation.
     ])  # fmt:skip
 
     if nvols > 1:
-        motion_report = pe.Node(MotionPlot(), name='motion_report', mem_gb=0.1)
+        motion_report = pe.Node(
+            MotionPlot(), name='motion_report', mem_gb=mem_gb['motion_report']
+        )
         ds_motion_report = pe.Node(
             DerivativesDataSink(
                 base_directory=petprep_dir,

--- a/petprep/workflows/pet/tests/test_base.py
+++ b/petprep/workflows/pet/tests/test_base.py
@@ -7,6 +7,7 @@ from nipype.pipeline.engine.utils import generate_expanded_graph
 from niworkflows.utils.testing import generate_bids_skeleton
 
 from .... import config
+from ....utils.misc import estimate_pet_mem_usage
 from ...tests import mock_config
 from ...tests.test_base import BASE_LAYOUT
 from ..base import init_pet_wf
@@ -114,6 +115,19 @@ def test_pet_wf_without_pvc(bids_root: Path):
         wf = init_pet_wf(pet_series=pet_series, precomputed={})
 
     assert not any(n.startswith('pet_pvc_wf') for n in wf.list_node_names())
+
+
+def test_motion_report_uses_estimated_memory(bids_root: Path):
+    """Motion reportlet reserves memory from the PET memory heuristic."""
+    pet_series = _prep_pet_series(bids_root)
+    _, mem_gb = estimate_pet_mem_usage(pet_series[0])
+
+    with mock_config(bids_dir=bids_root):
+        wf = init_pet_wf(pet_series=pet_series, precomputed={})
+
+    motion_report = wf.get_node('motion_report')
+    assert motion_report.mem_gb == mem_gb['motion_report']
+    assert motion_report.mem_gb > 0.1
 
 
 def test_pvc_entity_added(bids_root: Path):

--- a/petprep/workflows/pet/tests/test_mem.py
+++ b/petprep/workflows/pet/tests/test_mem.py
@@ -4,6 +4,10 @@ import numpy as np
 from petprep.utils.misc import estimate_pet_mem_usage
 
 
+def _expected_motion_report_mem_gb(size_gb, tlen):
+    return max(1.0, size_gb * 2.5 + tlen * 0.03)
+
+
 def test_estimate_pet_mem_usage(tmp_path):
     img = nb.Nifti1Image(np.zeros((5, 5, 5, 10)), np.eye(4))
     pet_file = tmp_path / 'pet.nii.gz'
@@ -15,6 +19,20 @@ def test_estimate_pet_mem_usage(tmp_path):
     assert np.isclose(mem['filesize'], size)
     assert np.isclose(mem['resampled'], size * 4)
     assert np.isclose(mem['largemem'], size * (max(tlen / 100, 1.0) + 4))
+    assert np.isclose(mem['motion_report'], _expected_motion_report_mem_gb(size, tlen))
+
+
+def test_estimate_pet_mem_usage_motion_report_scales_with_large_pet(tmp_path):
+    img = nb.Nifti1Image(np.zeros((100, 100, 100, 30), dtype=np.float32), np.eye(4))
+    pet_file = tmp_path / 'large_pet.nii.gz'
+    img.to_filename(pet_file)
+
+    tlen, mem = estimate_pet_mem_usage(str(pet_file))
+    size = 8 * np.prod(img.shape) / (1024**3)
+
+    assert tlen == 30
+    assert mem['motion_report'] > mem['filesize']
+    assert np.isclose(mem['motion_report'], _expected_motion_report_mem_gb(size, tlen))
 
 
 def test_estimate_pet_mem_usage_refreshes_overwritten_file(tmp_path):


### PR DESCRIPTION
This PR replaces the fixed 0.1 GB memory reservation for the PET MotionPlot reportlet with a data-driven estimate derived from the PET series size and frame count.

MotionPlot can use much more than 0.1 GB for large dynamic PET series because it renders before/after PNGs for each frame, keeps the rendered frames in memory, and embeds them as base64 images in an animated SVG. Underestimating this node’s memory can let Nipype schedule too many reportlet jobs concurrently and trigger abrupt worker termination.

Changes included:

1. Adds a motion_report entry to estimate_pet_mem_usage().
2. Estimates reportlet memory as image buffers plus per-frame rendered animation overhead.
3. Uses mem_gb['motion_report'] when creating the motion_report node.
4. Adds tests for the new memory estimate and workflow wiring.

This should reduce BrokenProcessPool failures during PET motion report generation for high-resolution or multi-frame PET series.