### PR TITLE
STY: Apply Ruff-suggested cleanups

### DIFF
--- a/.maint/update_authors.py
+++ b/.maint/update_authors.py
@@ -140,7 +140,7 @@ def get_git_lines(fname='line-contributors.txt'):
 
     git_line_summary_path = shutil.which('git-line-summary')
     if not git_line_summary_path:
-        git_line_summary_path = 'git summary --dedup-by-email'.split(' ')
+        git_line_summary_path = ['git', 'summary', '--dedup-by-email']
     else:
         git_line_summary_path = [git_line_summary_path]
 
@@ -171,7 +171,6 @@ def _namelast(inlist):
 @click.group()
 def cli():
     """Generate authorship boilerplates."""
-    pass
 
 
 @cli.command()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ from sphinx import __version__ as sphinxversion
 sys.path.append(os.path.abspath('sphinxext'))
 sys.path.insert(0, os.path.abspath('../wrapper'))
 
-from github_link import make_linkcode_resolve  # noqa: E402
+from github_link import make_linkcode_resolve
 
 # -- General configuration ------------------------------------------------
 

--- a/petprep/cli/tests/test_parser.py
+++ b/petprep/cli/tests/test_parser.py
@@ -416,7 +416,7 @@ def test_derivatives(tmp_path):
     # Providing --derivatives with names should use them
     temp_args = args + [
         '--derivatives',
-        f'anat={str(bids_path / "derivatives/smriprep")}',
+        f'anat={bids_path / "derivatives/smriprep"!s}',
     ]
     opts = parser.parse_args(temp_args)
     assert opts.derivatives == {'anat': bids_path / 'derivatives/smriprep'}

--- a/petprep/interfaces/__init__.py
+++ b/petprep/interfaces/__init__.py
@@ -13,10 +13,10 @@ class DerivativesDataSink(_DDSink):
 
 
 __all__ = (
-    'DerivativesDataSink',
-    'GeneratePetCifti',
-    'ExtractTACs',
-    'ExtractRefTAC',
-    'MotionPlot',
     'AtlasROIsReport',
+    'DerivativesDataSink',
+    'ExtractRefTAC',
+    'ExtractTACs',
+    'GeneratePetCifti',
+    'MotionPlot',
 )

--- a/petprep/interfaces/reports.py
+++ b/petprep/interfaces/reports.py
@@ -669,7 +669,7 @@ class AtlasROIsReport(SimpleInterface):
             if isinstance(legend_text, (bytes, bytearray)):
                 legend_text = legend_text.decode('utf-8')
             legend_text = legend_text.split('\n', 1)[-1]
-            inner_match = re.search(r'<svg[^>]*>(.*)</svg>', legend_text, re.S)
+            inner_match = re.search(r'<svg[^>]*>(.*)</svg>', legend_text, re.DOTALL)
             legend_body = inner_match.group(1) if inner_match else legend_text
             legend_width, legend_height = _extract_dims_from_text(legend_text)
             scale = width / legend_width if legend_width else 1.0

--- a/petprep/interfaces/tacs.py
+++ b/petprep/interfaces/tacs.py
@@ -148,4 +148,4 @@ class ExtractRefTAC(SimpleInterface):
         return runtime
 
 
-__all__ = ('ExtractTACs', 'ExtractRefTAC')
+__all__ = ('ExtractRefTAC', 'ExtractTACs')

--- a/petprep/reports/tests/test_reports.py
+++ b/petprep/reports/tests/test_reports.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 import pytest
 from bids.layout import BIDSLayout
 
-import petprep.reports.core as core
+from petprep.reports import core
 from petprep.reports.core import generate_reports
 
 from ... import config, data
@@ -164,7 +164,6 @@ def test_reportlets_dir_scoped_to_subject(tmp_path, monkeypatch):
 
     def _record_reportlets_dir(*args, reportlets_dir=None, **kwargs):
         recorded_reportlets.append(reportlets_dir)
-        return None
 
     monkeypatch.setattr(core, 'run_reports', _record_reportlets_dir)
     monkeypatch.setattr(config.execution, 'aggr_ses_reports', 4)
@@ -185,7 +184,6 @@ def test_generate_reports_uses_indexed_session_entities(tmp_path, monkeypatch):
 
     def _record_report(*args, session=None, **kwargs):
         recorded_sessions.append(session)
-        return None
 
     class _Layout:
         def get(self, return_type='object', subject=None, session=None, **kwargs):
@@ -218,7 +216,6 @@ def test_generate_reports_sessionwise_includes_anatomical_per_session(tmp_path, 
                 'session': session,
             }
         )
-        return None
 
     class _Layout:
         def get_sessions(self, subject=None, **kwargs):

--- a/petprep/utils/reference_mask.py
+++ b/petprep/utils/reference_mask.py
@@ -39,7 +39,7 @@ def generate_reference_region(
         mask = binary_erosion(mask, ball(config['erode_by_voxels'])).astype(np.uint8)
 
     # Step 3: Optional exclusion
-    if 'exclude_indices' in config and config['exclude_indices']:
+    if config.get('exclude_indices'):
         exclude = np.isin(data, config['exclude_indices'])  # bool mask
         if 'dilate_by_voxels' in config and config['dilate_by_voxels'] > 0:
             exclude = binary_dilation(exclude, ball(config['dilate_by_voxels']))

--- a/petprep/utils/tests/test_atlas.py
+++ b/petprep/utils/tests/test_atlas.py
@@ -78,6 +78,6 @@ def test_get_atlas_files_missing_entries(monkeypatch):
 
 
 def test_get_atlas_files_unknown_atlas(monkeypatch):
-    monkeypatch.setattr(atlas, 'load_atlas_config', lambda: {})
+    monkeypatch.setattr(atlas, 'load_atlas_config', dict)
     with pytest.raises(ValueError, match='is not defined'):
         atlas.get_atlas_files('Missing')

--- a/petprep/workflows/pet/__init__.py
+++ b/petprep/workflows/pet/__init__.py
@@ -25,8 +25,8 @@ from .tacs import init_pet_tacs_wf
 __all__ = [
     'init_pet_confs_wf',
     'init_pet_hmc_wf',
+    'init_pet_ref_tacs_wf',
     'init_pet_reg_wf',
     'init_pet_surf_wf',
     'init_pet_tacs_wf',
-    'init_pet_ref_tacs_wf',
 ]

--- a/petprep/workflows/pet/outputs.py
+++ b/petprep/workflows/pet/outputs.py
@@ -436,17 +436,17 @@ def init_func_fit_reports_wf(
 
 
 __all__ = (
-    'prepare_timing_parameters',
-    'init_func_fit_reports_wf',
-    'init_ds_petref_wf',
-    'init_ds_petmask_wf',
-    'init_ds_refmask_wf',
-    'init_ds_registration_wf',
     'init_ds_hmc_wf',
     'init_ds_pet_native_wf',
+    'init_ds_petmask_wf',
+    'init_ds_petref_wf',
+    'init_ds_refmask_wf',
+    'init_ds_registration_wf',
     'init_ds_volumes_wf',
+    'init_func_fit_reports_wf',
     'init_pet_preproc_report_wf',
     'init_refmask_report_wf',
+    'prepare_timing_parameters',
 )
 
 

--- a/petprep/workflows/pet/tests/test_fit.py
+++ b/petprep/workflows/pet/tests/test_fit.py
@@ -698,22 +698,20 @@ def test_pet_fit_requires_both_derivatives(bids_root: Path, tmp_path: Path):
     np.savetxt(hmc_xfm, np.eye(4))
 
     # Only petref provided
-    with mock_config(bids_dir=bids_root):
-        with pytest.raises(ValueError):  # noqa: PT011
-            init_pet_fit_wf(
-                pet_series=pet_series,
-                precomputed={'petref': str(ref_file)},
-                omp_nthreads=1,
-            )
+    with mock_config(bids_dir=bids_root), pytest.raises(ValueError):  # noqa: PT011
+        init_pet_fit_wf(
+            pet_series=pet_series,
+            precomputed={'petref': str(ref_file)},
+            omp_nthreads=1,
+        )
 
     # Only hmc transforms provided
-    with mock_config(bids_dir=bids_root):
-        with pytest.raises(ValueError):  # noqa: PT011
-            init_pet_fit_wf(
-                pet_series=pet_series,
-                precomputed={'transforms': {'hmc': str(hmc_xfm)}},
-                omp_nthreads=1,
-            )
+    with mock_config(bids_dir=bids_root), pytest.raises(ValueError):  # noqa: PT011
+        init_pet_fit_wf(
+            pet_series=pet_series,
+            precomputed={'transforms': {'hmc': str(hmc_xfm)}},
+            omp_nthreads=1,
+        )
 
 
 def test_pet_fit_stage1_with_cached_baseline(bids_root: Path, tmp_path: Path):
@@ -963,7 +961,6 @@ class _FakeFallbackWorkflow:
             self.inputs.inputnode.anat_preproc,
             self.inputs.inputnode.anat_mask,
         )
-        return None
 
 
 def test_pet_coreg_fallback_interface_runs_uncropped_workflow(monkeypatch, tmp_path):
@@ -1596,7 +1593,7 @@ def test_extract_twa_image_validation(
     pet_file = tmp_path / 'pet.nii.gz'
     pet_img.to_filename(pet_file)
 
-    with pytest.raises(ValueError, match=message):  # noqa: PT011
+    with pytest.raises(ValueError, match=message):
         _extract_twa_image(
             str(pet_file),
             tmp_path / 'out',

--- a/wrapper/pyproject.toml
+++ b/wrapper/pyproject.toml
@@ -101,6 +101,7 @@ inline-quotes = "single"
 
 [tool.ruff.lint.extend-per-file-ignores]
 "*/test_*.py" = ["S101"]
+"src/petprep_docker/__main__.py" = ["UP032"]  # Wrapper supports Python 2.7.
 "petprep/utils/debug.py" = ["A002", "T100"]
 "docs/conf.py" = ["A001"]
 

--- a/wrapper/src/petprep_docker/__main__.py
+++ b/wrapper/src/petprep_docker/__main__.py
@@ -147,9 +147,12 @@ def merge_help(wrapper_help, target_help):
             line = targ.lstrip()
             if line.startswith('usage'):
                 continue
-            if line[0].isalnum() or line[0] == '{':
-                posargs.append(line)
-            elif line[0] == '[' and (line[1].isalnum() or line[1] == '{'):
+            if (
+                line[0].isalnum()
+                or line[0] == '{'
+                or line[0] == '['
+                and (line[1].isalnum() or line[1] == '{')
+            ):
                 posargs.append(line)
         return ' '.join(posargs)
 
@@ -293,7 +296,7 @@ def get_parser():
         '--image',
         metavar='IMG',
         type=str,
-        default='nipreps/petprep:{}'.format(__version__),
+        default=f'nipreps/petprep:{__version__}',
         help='image name',
     )
 
@@ -420,7 +423,7 @@ def main():
     check = check_docker()
     if check < 1:
         if opts.version:
-            print('petprep wrapper {!s}'.format(__version__))
+            print(f'petprep wrapper {__version__!s}')
         if opts.help:
             parser.print_help()
         if check == -1:
@@ -433,7 +436,7 @@ def main():
     if not check_image(opts.image):
         resp = 'Y'
         if opts.version:
-            print('petprep wrapper {!s}'.format(__version__))
+            print(f'petprep wrapper {__version__!s}')
         if opts.help:
             parser.print_help()
         if opts.version or opts.help:
@@ -486,7 +489,7 @@ def main():
     # Patch working repositories into installed package directories
     if opts.patch:
         for pkg, repo_path in opts.patch.items():
-            command.extend(['-v', '{}:{}/{}:ro'.format(repo_path, PKG_PATH, pkg)])
+            command.extend(['-v', f'{repo_path}:{PKG_PATH}/{pkg}:ro'])
 
     if opts.env:
         for envvar in opts.env:
@@ -496,7 +499,7 @@ def main():
         command.extend(['-u', opts.user])
 
     if opts.fs_license_file:
-        command.extend(['-v', '{}:/opt/freesurfer/license.txt:ro'.format(opts.fs_license_file)])
+        command.extend(['-v', f'{opts.fs_license_file}:/opt/freesurfer/license.txt:ro'])
 
     main_args = []
     if opts.bids_dir:
@@ -511,19 +514,19 @@ def main():
     main_args.append(opts.analysis_level)
 
     if opts.fs_subjects_dir:
-        command.extend(['-v', '{}:/opt/subjects'.format(opts.fs_subjects_dir)])
+        command.extend(['-v', f'{opts.fs_subjects_dir}:/opt/subjects'])
         unknown_args.extend(['--fs-subjects-dir', '/opt/subjects'])
 
     if opts.config_file:
-        command.extend(['-v', '{}:/tmp/config.toml'.format(opts.config_file)])
+        command.extend(['-v', f'{opts.config_file}:/tmp/config.toml'])
         unknown_args.extend(['--config-file', '/tmp/config.toml'])
 
     # Patch derivatives for searching
     if opts.derivatives:
         unknown_args.append('--derivatives')
         for deriv, deriv_path in opts.derivatives.items():
-            command.extend(['-v', '{}:/deriv/{}:ro'.format(deriv_path, deriv)])
-            unknown_args.append('/deriv/{}'.format(deriv))
+            command.extend(['-v', f'{deriv_path}:/deriv/{deriv}:ro'])
+            unknown_args.append(f'/deriv/{deriv}')
 
     if opts.work_dir:
         command.extend(['-v', ':'.join((opts.work_dir, '/scratch'))])
@@ -595,7 +598,7 @@ def main():
     print('RUNNING: ' + ' '.join(command))
     ret = subprocess.run(command)
     if ret.returncode:
-        print('PETPrep: Please report errors to {}'.format(__bugreports__))
+        print(f'PETPrep: Please report errors to {__bugreports__}')
     return ret.returncode
 
 

--- a/wrapper/src/petprep_docker/__main__.py
+++ b/wrapper/src/petprep_docker/__main__.py
@@ -296,7 +296,7 @@ def get_parser():
         '--image',
         metavar='IMG',
         type=str,
-        default=f'nipreps/petprep:{__version__}',
+        default='nipreps/petprep:{}'.format(__version__),
         help='image name',
     )
 
@@ -423,7 +423,7 @@ def main():
     check = check_docker()
     if check < 1:
         if opts.version:
-            print(f'petprep wrapper {__version__!s}')
+            print('petprep wrapper {!s}'.format(__version__))
         if opts.help:
             parser.print_help()
         if check == -1:
@@ -436,7 +436,7 @@ def main():
     if not check_image(opts.image):
         resp = 'Y'
         if opts.version:
-            print(f'petprep wrapper {__version__!s}')
+            print('petprep wrapper {!s}'.format(__version__))
         if opts.help:
             parser.print_help()
         if opts.version or opts.help:
@@ -489,7 +489,7 @@ def main():
     # Patch working repositories into installed package directories
     if opts.patch:
         for pkg, repo_path in opts.patch.items():
-            command.extend(['-v', f'{repo_path}:{PKG_PATH}/{pkg}:ro'])
+            command.extend(['-v', '{}:{}/{}:ro'.format(repo_path, PKG_PATH, pkg)])
 
     if opts.env:
         for envvar in opts.env:
@@ -499,7 +499,7 @@ def main():
         command.extend(['-u', opts.user])
 
     if opts.fs_license_file:
-        command.extend(['-v', f'{opts.fs_license_file}:/opt/freesurfer/license.txt:ro'])
+        command.extend(['-v', '{}:/opt/freesurfer/license.txt:ro'.format(opts.fs_license_file)])
 
     main_args = []
     if opts.bids_dir:
@@ -514,19 +514,19 @@ def main():
     main_args.append(opts.analysis_level)
 
     if opts.fs_subjects_dir:
-        command.extend(['-v', f'{opts.fs_subjects_dir}:/opt/subjects'])
+        command.extend(['-v', '{}:/opt/subjects'.format(opts.fs_subjects_dir)])
         unknown_args.extend(['--fs-subjects-dir', '/opt/subjects'])
 
     if opts.config_file:
-        command.extend(['-v', f'{opts.config_file}:/tmp/config.toml'])
+        command.extend(['-v', '{}:/tmp/config.toml'.format(opts.config_file)])
         unknown_args.extend(['--config-file', '/tmp/config.toml'])
 
     # Patch derivatives for searching
     if opts.derivatives:
         unknown_args.append('--derivatives')
         for deriv, deriv_path in opts.derivatives.items():
-            command.extend(['-v', f'{deriv_path}:/deriv/{deriv}:ro'])
-            unknown_args.append(f'/deriv/{deriv}')
+            command.extend(['-v', '{}:/deriv/{}:ro'.format(deriv_path, deriv)])
+            unknown_args.append('/deriv/{}'.format(deriv))
 
     if opts.work_dir:
         command.extend(['-v', ':'.join((opts.work_dir, '/scratch'))])
@@ -598,7 +598,7 @@ def main():
     print('RUNNING: ' + ' '.join(command))
     ret = subprocess.run(command)
     if ret.returncode:
-        print(f'PETPrep: Please report errors to {__bugreports__}')
+        print('PETPrep: Please report errors to {}'.format(__bugreports__))
     return ret.returncode
 
 


### PR DESCRIPTION
- Apply Ruff-suggested cleanups across maintenance scripts, package exports, tests, and the Docker wrapper.
- Simplify imports, string formatting, collection construction, and redundant returns.
- Keep these mechanical changes separate from feature development.

No behavioral changes are intended.